### PR TITLE
Apple Music: Fix album art download

### DIFF
--- a/src/common/services/applemusic/resolve.ts
+++ b/src/common/services/applemusic/resolve.ts
@@ -131,11 +131,16 @@ export const resolve: ResolveFunction = async (url) => {
 
     coverArt = asArray(
       pipe(
-        document_.querySelector<HTMLMetaElement>('meta[property="og:image"]') ??
-          undefined,
-        ifDefined((el) =>
-          el.content.replace(/\d+x\d+bf-\d+\.jpg/, `${FULL_IMAGE_SIZE}.jpg`),
+        document_.querySelector<HTMLSourceElement>(
+          'div[slot="artwork"] source[type="image/jpeg"]',
         ),
+        ifDefined((el) => {
+          // get the last (largest?) srcset entry, take URL before whitespace
+          const srcset = el?.attributes?.srcset?.value
+          if (!srcset) return undefined
+          const lastSrc = srcset.split(',').pop()?.trim()
+          return lastSrc ? lastSrc.split(' ')[0] : undefined
+        }),
       ),
     )
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       preact(),
       webExtension({
-        manifest: getManifest(Number(env.MANIFEST_VERSION)),
+        manifest: getManifest(Number(env.MANIFEST_VERSION) || 3),
       }),
     ],
     resolve: {


### PR DESCRIPTION
A recent change in Apple Music caused cover art to be download with a large white background.