### PR TITLE
feat: Apple Music per-track credits, VA detection, and checkmark fix

### DIFF
--- a/src/modules/cover-art/cover-art-downloader.tsx
+++ b/src/modules/cover-art/cover-art-downloader.tsx
@@ -11,12 +11,13 @@ import {
 	failed,
 	fold,
 	initial,
+	isComplete,
 	loading,
 } from "~/shared/utils/one-shot";
 import { pipe } from "~/shared/utils/pipe";
 
 export function CoverArtDownloader() {
-	const { info, fetchInfo } = useReleaseInfo();
+	const { info, setInfo, fetchInfo } = useReleaseInfo();
 	const [state, setState] = useState<OneShot<Error, ResolveData>>(initial);
 
 	useEffect(() => {
@@ -71,7 +72,10 @@ export function CoverArtDownloader() {
 					services={RESOLVABLES}
 					submitText="Download"
 					data={state}
-					onSubmit={(url, service) => void fetchInfo(url, service)}
+					onSubmit={async (url, service) => {
+						const result = await fetchInfo(url, service);
+						if (isComplete(result)) setInfo(result);
+					}}
 				/>
 			</div>
 		</>

--- a/src/modules/release-submission/use-cases/import-controls.tsx
+++ b/src/modules/release-submission/use-cases/import-controls.tsx
@@ -23,28 +23,31 @@ export default async function injectImportControls() {
 }
 
 function Import() {
-	const { info, fetchInfo } = useReleaseInfo();
+	const { info, setInfo, fetchInfo } = useReleaseInfo();
 	const [formOptions, setFormOptions] = useState(DEFAULT_FORM_OPTIONS);
 
 	const fetchInfoOuter = useCallback(
 		async (url: string, service: Service & Resolvable) => {
-			const info = await fetchInfo(url, service);
-			if (isComplete(info)) {
-				void fill(info.data, formOptions);
+			const resolvedInfo = await fetchInfo(url, service);
+			if (isComplete(resolvedInfo)) {
+				await fill(resolvedInfo.data, formOptions);
+				setInfo(resolvedInfo);
 
 				// emit import event
 				const importEvent = new CustomEvent<ResolveData>("importEvent", {
-					detail: info.data,
+					detail: resolvedInfo.data,
 				});
 				document.dispatchEvent(importEvent);
 
-				if (formOptions.downloadArt && info.data.coverArt) {
-					const filename = getFilename(info.data);
-					await download(info.data.coverArt.map((url) => ({ url, filename })));
+				if (formOptions.downloadArt && resolvedInfo.data.coverArt) {
+					const filename = getFilename(resolvedInfo.data);
+					await download(
+						resolvedInfo.data.coverArt.map((url) => ({ url, filename })),
+					);
 				}
 			}
 		},
-		[fetchInfo, formOptions],
+		[fetchInfo, setInfo, formOptions],
 	);
 
 	return (

--- a/src/modules/release-submission/use-cases/import-controls.tsx
+++ b/src/modules/release-submission/use-cases/import-controls.tsx
@@ -204,6 +204,7 @@ const FIELDS_MAP: Record<FillField, string> = {
 	attributes: "Issue Attributes",
 	tracks: "Tracklist",
 	countries: "Countries Issued",
+	credits: "Credits",
 };
 
 const DEFAULT_FORM_OPTIONS: ImportOptions = {

--- a/src/modules/release-submission/utils/fillers.ts
+++ b/src/modules/release-submission/utils/fillers.ts
@@ -78,17 +78,51 @@ async function fillExtraFields(
 async function fillArtists(artists: string[]) {
 	if (artists[0]?.toLowerCase() === "various artists") {
 		forceQuerySelector<HTMLInputElement>(document)("#cat_va").click();
-		for (const link of document.querySelectorAll<HTMLAnchorElement>(
-			"#filed_under_performerx .filed_under_delete a",
-		)) {
-			link.click();
-		}
-	} else {
-		// Regular release
-		if (document.querySelector(".sortable_filed_under_performer") !== null)
-			return;
+		switchAwayFromSameAsParent();
+		clearFiledUnderPerformers();
+		return;
+	}
 
-		for (const artist of artists) await fillArtist(artist);
+	if (filedUnderPerformersMatch(artists)) return;
+
+	switchAwayFromSameAsParent();
+	clearFiledUnderPerformers();
+	for (const artist of artists) await fillArtist(artist);
+}
+
+function getFiledUnderPerformerNames(): string[] {
+	return [...document.querySelectorAll(".sortable_filed_under_performer")].map(
+		(entry) =>
+			entry
+				.querySelector(".filed_under_artist_preview .rendered_text")
+				?.textContent?.trim() ?? "",
+	);
+}
+
+function filedUnderPerformersMatch(artists: string[]): boolean {
+	const current = getFiledUnderPerformerNames();
+	if (current.length !== artists.length) return false;
+
+	const normalize = (names: string[]) =>
+		names.map((name) => name.toLowerCase()).sort();
+	const normalizedCurrent = normalize(current);
+	const normalizedArtists = normalize(artists);
+	return normalizedCurrent.every(
+		(name, index) => name === normalizedArtists[index],
+	);
+}
+
+function switchAwayFromSameAsParent() {
+	document
+		.querySelector<HTMLInputElement>("#filed_under_same_as_parent_no")
+		?.click();
+}
+
+function clearFiledUnderPerformers() {
+	for (const link of document.querySelectorAll<HTMLAnchorElement>(
+		"#filed_under_performerx .filed_under_delete a",
+	)) {
+		link.click();
 	}
 }
 

--- a/src/modules/release-submission/utils/fillers.ts
+++ b/src/modules/release-submission/utils/fillers.ts
@@ -77,8 +77,12 @@ async function fillExtraFields(
 
 async function fillArtists(artists: string[]) {
 	if (artists[0]?.toLowerCase() === "various artists") {
-		// Various Artists release
 		forceQuerySelector<HTMLInputElement>(document)("#cat_va").click();
+		for (const link of document.querySelectorAll<HTMLAnchorElement>(
+			"#filed_under_performerx .filed_under_delete a",
+		)) {
+			link.click();
+		}
 	} else {
 		// Regular release
 		if (document.querySelector(".sortable_filed_under_performer") !== null)

--- a/src/modules/release-submission/utils/fillers.ts
+++ b/src/modules/release-submission/utils/fillers.ts
@@ -70,6 +70,9 @@ async function fillExtraFields(
 	if (data.countries != null && options.fillFields.countries) {
 		fillCountries(data.countries);
 	}
+	if (data.tracks != null && options.fillFields.credits) {
+		await fillCredits(data.tracks);
+	}
 }
 
 async function fillArtists(artists: string[]) {
@@ -214,6 +217,43 @@ async function fillTracks(tracks: Track[], capitalization: CapitalizationType) {
 	forceQuerySelector<HTMLTextAreaElement>(document)("#track_advanced").value =
 		tracksString;
 	await runScript(`document.querySelector('#goSimpleBtn').click()`);
+}
+
+async function fillCredits(tracks: Track[]): Promise<void> {
+	const artistTracks = new Map<string, string[]>();
+	for (const track of tracks) {
+		if (!track.artists || !track.position) continue;
+		for (const artist of track.artists) {
+			if (!artistTracks.has(artist)) artistTracks.set(artist, []);
+			artistTracks.get(artist)!.push(track.position);
+		}
+	}
+	for (const [artist, positions] of artistTracks) {
+		await fillCredit(artist, "performer", positions.join(", "));
+	}
+}
+
+async function fillCredit(
+	artist: string,
+	role: string,
+	tracks: string,
+): Promise<void> {
+	forceQuerySelector<HTMLInputElement>(document)("#credit_searchterm").value =
+		artist;
+	forceQuerySelector<HTMLInputElement>(document)(
+		"#section_credits .gosearch input[type=button]",
+	).click();
+	const topResult = await waitForResult(
+		forceQuerySelector<HTMLIFrameElement>(document)("#creditlist"),
+	);
+	if (!topResult) return;
+	topResult.click();
+	forceQuerySelector<HTMLInputElement>(document)(
+		"#creditsx li:last-child .credits_roles input",
+	).value = role;
+	forceQuerySelector<HTMLInputElement>(document)(
+		"#creditsx li:last-child .credits_tracks input",
+	).value = tracks;
 }
 
 function fillSource(url: string) {

--- a/src/modules/release-submission/utils/types.ts
+++ b/src/modules/release-submission/utils/types.ts
@@ -13,5 +13,6 @@ export type ReleaseOptions = {
 		tracks: boolean;
 		label: boolean;
 		countries: boolean;
+		credits: boolean;
 	};
 };

--- a/src/shared/services/applemusic/resolve.test.ts
+++ b/src/shared/services/applemusic/resolve.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { convertAppleMusicDuration } from "./convert";
+import { extractTrackArtist, TRACK_NUMBER_REGEX } from "./track-artists";
 
 describe("convertAppleMusicDuration", () => {
 	const cases = [
@@ -11,5 +12,41 @@ describe("convertAppleMusicDuration", () => {
 
 	test.each(cases)("converts %s to %s", (input, output) => {
 		expect(convertAppleMusicDuration(input)).toEqual(output);
+	});
+});
+
+describe("extractTrackArtist", () => {
+	test("extracts the artist within the track's own object", () => {
+		const scriptText =
+			'{"trackNumber":1,"subtitleLinks":[{"title":"Artist A"}],"other":"x"},' +
+			'{"trackNumber":2,"subtitleLinks":[{"title":"Artist B"}],"other":"y"}';
+		const matches = [...scriptText.matchAll(TRACK_NUMBER_REGEX)];
+
+		expect(extractTrackArtist(scriptText, matches[0])).toBe("Artist A");
+		expect(extractTrackArtist(scriptText, matches[1])).toBe("Artist B");
+	});
+
+	test("handles nested objects between trackNumber and subtitleLinks", () => {
+		const scriptText =
+			'{"trackNumber":1,"contentDescriptor":{"kind":"song","identifiers":' +
+			'{"storeAdamID":"1"}},"subtitleLinks":[{"title":"Artist A"}]}';
+		const [match] = scriptText.matchAll(TRACK_NUMBER_REGEX);
+
+		expect(extractTrackArtist(scriptText, match)).toBe("Artist A");
+	});
+
+	test("does not leak into unrelated content when a track has no subtitleLinks", () => {
+		// Regression: the final track had "subtitleLinks":null with no next
+		// trackNumber to bound the search, so the old lazy-match regex matched an
+		// unrelated "subtitleLinks" entry from a later section of the script
+		// instead of correctly finding nothing.
+		const scriptText =
+			'{"trackNumber":1,"subtitleLinks":[{"title":"Artist A"}]},' +
+			'{"trackNumber":2,"subtitleLinks":null},' +
+			'"recommendations":{"subtitleLinks":[{"title":"2020"}]}';
+		const matches = [...scriptText.matchAll(TRACK_NUMBER_REGEX)];
+
+		expect(extractTrackArtist(scriptText, matches[0])).toBe("Artist A");
+		expect(extractTrackArtist(scriptText, matches[1])).toBeUndefined();
 	});
 });

--- a/src/shared/services/applemusic/resolve.ts
+++ b/src/shared/services/applemusic/resolve.ts
@@ -97,15 +97,36 @@ const parseLabelAndType = (
 	};
 };
 
+const getTrackArtists = (document_: Document): Map<number, string> => {
+	const map = new Map<number, string>();
+	const regex =
+		/"trackNumber":(\d+)(?:(?!"trackNumber":).)*?"subtitleLinks":\[\{"title":"([^"]*)"/gs;
+	for (const script of document_.querySelectorAll("script")) {
+		if (!script.text.includes("track-lockup")) continue;
+		for (const match of script.text.matchAll(regex)) {
+			const trackNum = Number.parseInt(match[1], 10);
+			if (!map.has(trackNum)) map.set(trackNum, match[2]);
+		}
+		break;
+	}
+	return map;
+};
+
 const resolveAlbumFields = (
 	release: ReleaseData,
 	document_: Document,
 ): ResolvedFields => {
-	const tracks = release.tracks.map((t, i) => ({
-		position: String(i + 1),
-		title: t.name,
-		duration: ifDefined(convertAppleMusicDuration)(t.duration),
-	}));
+	const trackArtists = getTrackArtists(document_);
+	const tracks = release.tracks.map((t, i) => {
+		const position = String(i + 1);
+		const artist = trackArtists.get(i + 1);
+		return {
+			position,
+			title: t.name,
+			duration: ifDefined(convertAppleMusicDuration)(t.duration),
+			...(artist !== undefined ? { artists: [artist] } : {}),
+		};
+	});
 
 	const { title, type: titleType } = parseTitleAndType(
 		release.name,

--- a/src/shared/services/applemusic/resolve.ts
+++ b/src/shared/services/applemusic/resolve.ts
@@ -97,6 +97,16 @@ const parseLabelAndType = (
 	};
 };
 
+const getIsVariousArtists = (document_: Document): boolean => {
+	for (const script of document_.querySelectorAll("script")) {
+		if (!script.text.includes("track-lockup")) continue;
+		if (script.text.includes('"subtitleLinks":[{"title":"Various Artists"'))
+			return true;
+		break;
+	}
+	return false;
+};
+
 const getTrackArtists = (document_: Document): Map<number, string> => {
 	const map = new Map<number, string>();
 	const regex =
@@ -149,8 +159,12 @@ const resolveAlbumFields = (
 		),
 	);
 
+	const artists = getIsVariousArtists(document_)
+		? ["Various Artists"]
+		: release.byArtist.map((a) => a.name);
+
 	return {
-		artists: release.byArtist.map((a) => a.name),
+		artists,
 		title,
 		type,
 		format: "lossless digital",

--- a/src/shared/services/applemusic/resolve.ts
+++ b/src/shared/services/applemusic/resolve.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types";
 import type { MusicVideoData, ReleaseData } from "./codec";
 import { convertAppleMusicDuration } from "./convert";
+import { getTrackArtists } from "./track-artists";
 
 const FULL_IMAGE_SIZE = "3000x3000bb.jpg";
 
@@ -105,21 +106,6 @@ const getIsVariousArtists = (document_: Document): boolean => {
 		break;
 	}
 	return false;
-};
-
-const getTrackArtists = (document_: Document): Map<number, string> => {
-	const map = new Map<number, string>();
-	const regex =
-		/"trackNumber":(\d+)(?:(?!"trackNumber":).)*?"subtitleLinks":\[\{"title":"([^"]*)"/gs;
-	for (const script of document_.querySelectorAll("script")) {
-		if (!script.text.includes("track-lockup")) continue;
-		for (const match of script.text.matchAll(regex)) {
-			const trackNum = Number.parseInt(match[1], 10);
-			if (!map.has(trackNum)) map.set(trackNum, match[2]);
-		}
-		break;
-	}
-	return map;
 };
 
 const resolveAlbumFields = (

--- a/src/shared/services/applemusic/track-artists.ts
+++ b/src/shared/services/applemusic/track-artists.ts
@@ -1,0 +1,41 @@
+export const TRACK_NUMBER_REGEX = /"trackNumber":(\d+)/g;
+const SUBTITLE_TITLE_REGEX = /"subtitleLinks":\[\{"title":"([^"]*)"/;
+
+const findEnclosingObjectEnd = (text: string, startIndex: number): number => {
+	let depth = 0;
+	for (let i = startIndex; i < text.length; i++) {
+		if (text[i] === "{") depth += 1;
+		else if (text[i] === "}") {
+			depth -= 1;
+			if (depth < 0) return i;
+		}
+	}
+	return text.length;
+};
+
+export const extractTrackArtist = (
+	scriptText: string,
+	trackNumberMatch: RegExpMatchArray,
+): string | undefined => {
+	if (trackNumberMatch.index === undefined) return undefined;
+
+	const objectStart = trackNumberMatch.index + trackNumberMatch[0].length;
+	const objectEnd = findEnclosingObjectEnd(scriptText, objectStart);
+	const trackObjectText = scriptText.slice(objectStart, objectEnd);
+	return SUBTITLE_TITLE_REGEX.exec(trackObjectText)?.[1];
+};
+
+export const getTrackArtists = (document_: Document): Map<number, string> => {
+	const map = new Map<number, string>();
+	for (const script of document_.querySelectorAll("script")) {
+		if (!script.text.includes("track-lockup")) continue;
+		for (const match of script.text.matchAll(TRACK_NUMBER_REGEX)) {
+			const trackNum = Number.parseInt(match[1], 10);
+			if (map.has(trackNum)) continue;
+			const artist = extractTrackArtist(script.text, match);
+			if (artist !== undefined) map.set(trackNum, artist);
+		}
+		break;
+	}
+	return map;
+};

--- a/src/shared/services/types.ts
+++ b/src/shared/services/types.ts
@@ -197,6 +197,7 @@ export type Track = {
 	title?: string;
 	duration?: string;
 	header?: boolean;
+	artists?: string[];
 };
 
 export type ResolveData = {

--- a/src/shared/use-release-info.ts
+++ b/src/shared/use-release-info.ts
@@ -11,6 +11,7 @@ export type FetchFunction = (
 ) => Promise<InfoState>;
 export type UseReleaseInfoValue = {
 	info: InfoState;
+	setInfo: (info: InfoState) => void;
 	fetchInfo: FetchFunction;
 };
 
@@ -21,11 +22,11 @@ export const useReleaseInfo = (): UseReleaseInfoValue => {
 		setInfo(loading);
 		const nextInfo = await service
 			.resolve(url)
-			.then((info) => complete(info))
+			.then((data) => complete(data))
 			.catch((error) => failed(error));
-		setInfo(nextInfo);
+		if (nextInfo.type !== "complete") setInfo(nextInfo);
 		return nextInfo;
 	}, []);
 
-	return { info, fetchInfo };
+	return { info, setInfo, fetchInfo };
 };


### PR DESCRIPTION
## Summary

- **Auto-fill performer credits**: When importing from Apple Music, per-track artist data is extracted from the server-rendered script blob and used to fill the RYM credits section — one row per unique artist, role set to "performer", with the correct track numbers.
- **Various Artists detection**: Compilations are now detected by checking for `"Various Artists"` in the album-level `subtitleLinks` in Apple Music's script blob. When detected, the release category is switched to "Various Artists (non-classical)" and any existing filed-under performer entries are cleared.
- **Checkmark timing fix**: The import success checkmark is now deferred until after credits have finished filling, so the spinner stays active for the full operation.
- **Cover art downloader fix**: Fixes a regression from the checkmark timing change that broke the cover art downloader on the image upload page.

## Changes

- `src/shared/services/types.ts` — adds `artists?: string[]` to `Track`
- `src/shared/services/applemusic/resolve.ts` — extracts per-track artists and detects VA releases from the script blob
- `src/modules/release-submission/utils/types.ts` — adds `credits: boolean` to `fillFields`
- `src/modules/release-submission/utils/fillers.ts` — adds `fillCredits`/`fillCredit`, clears filed-under entries on VA releases
- `src/modules/release-submission/use-cases/import-controls.tsx` — defers checkmark until after `fill()` completes
- `src/shared/use-release-info.ts` — exposes `setInfo` so callers control when complete state is set
- `src/modules/cover-art/cover-art-downloader.tsx` — calls `setInfo` after `fetchInfo` to restore download trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)