### PR TITLE
feat: add chart-shortcuts module with keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ Hides community rating values while preserving page layout. A toggle reveals the
 
 ---
 
+### Chart Shortcuts
+
+On the chart-builder page (`/charts/`), adds keyboard shortcuts to the genre/descriptor search field so you can build a chart query without touching the mouse - e.g. type a genre, then press a shortcut to include or exclude it, toggle its sub-genres, or require all selected terms to match. A "Show shortcut hints" toggle next to the search field lists every current shortcut and what it does.
+
+The default modifier is Control on macOS and Alt elsewhere - Ctrl+letter (and Ctrl+1-8, which switches tabs in Chrome/Firefox) is heavily claimed by browser/OS shortcuts on Windows/Linux. Every shortcut is fully customizable:
+
+- In the extension popup, click **Customize shortcuts** next to the Chart Shortcuts toggle to open the shortcut editor.
+- Click the **+** next to any action to record a new key combo - just press the keys you want. Shortcuts must include Ctrl, Alt, or Cmd, so they don't interfere with typing in the search field.
+- Click **×** on an existing combo to remove it. An action can have more than one combo bound to it.
+- If a combo is already used by another action, the editor tells you which one, rather than silently overwriting it.
+- **Reset all to defaults** restores every shortcut to its original binding.
+- Rebinding takes effect immediately on any chart page you already have open - no refresh needed.
+- Your custom shortcuts persist across browser restarts.
+
+---
+
 ## Development
 
 ### Prerequisites

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -126,6 +126,11 @@ const sharedManifest = {
 			],
 			run_at: "document_idle",
 		},
+		{
+			js: ["src/modules/chart-shortcuts/main.ts"],
+			matches: ["*://*.rateyourmusic.com/charts/*"],
+			run_at: "document_start",
+		},
 	],
 	icons: {
 		"16": "icons/sonemic-16.png",

--- a/src/modules/background/index.ts
+++ b/src/modules/background/index.ts
@@ -3,12 +3,20 @@ import browser from "webextension-polyfill";
 import { getPageEnabled } from "~/shared/page-settings";
 import type { PageKey } from "~/shared/pages";
 import { globalPageKeys, pages } from "~/shared/pages";
-import type { BackgroundResponse } from "~/shared/utils/messaging";
-import { isBackgroundRequest } from "~/shared/utils/messaging";
+import type {
+	BackgroundResponse,
+	KeybindingsUpdatedMessage,
+} from "~/shared/utils/messaging";
+import {
+	isBackgroundRequest,
+	isKeybindingsChangedMessage,
+} from "~/shared/utils/messaging";
 
 import { download } from "./download";
 import { backgroundFetch } from "./fetch";
 import { script } from "./script";
+
+const CHART_PAGE_PATTERN = "*://*.rateyourmusic.com/charts/*";
 
 const getResponse = (
 	message: unknown,
@@ -22,7 +30,28 @@ const getResponse = (
 	throw new Error(`Invalid message: ${JSON.stringify(message)}`);
 };
 
+// Notifies any already-open chart page so a rebind made in the popup takes
+// effect without a refresh.
+const broadcastKeybindingsChanged = async (value: string): Promise<void> => {
+	const tabs = await browser.tabs.query({ url: CHART_PAGE_PATTERN });
+	await Promise.all(
+		tabs
+			.filter((tab): tab is typeof tab & { id: number } => tab.id != null)
+			.map((tab) =>
+				browser.tabs.sendMessage(tab.id, {
+					type: "keybindingsUpdated",
+					data: { value },
+				} satisfies KeybindingsUpdatedMessage),
+			),
+	);
+};
+
 browser.runtime.onMessage.addListener((message, sender) => {
+	if (isKeybindingsChangedMessage(message)) {
+		void broadcastKeybindingsChanged(message.data.value);
+		return undefined;
+	}
+
 	const tabId = sender.tab?.id;
 	if (tabId === undefined) return undefined;
 

--- a/src/modules/chart-shortcuts/app.ts
+++ b/src/modules/chart-shortcuts/app.ts
@@ -1,0 +1,467 @@
+import { runScript, waitForElement } from "~/shared/utils/dom";
+
+type Category = "genre" | "sec_genre" | "genre_either" | "descriptor";
+
+type FilterType =
+	| "genre_include"
+	| "genre_exclude"
+	| "sec_genre_include"
+	| "sec_genre_exclude"
+	| "genre_either_include"
+	| "genre_either_exclude"
+	| "descriptor_include"
+	| "descriptor_exclude";
+
+type CheckboxKind = "sub" | "all";
+
+type Scope = "genre" | "descriptor";
+
+type AdvancedToggle = {
+	id: string;
+	handler: string;
+};
+
+type BrowseResult = {
+	display_name?: string;
+	name?: string;
+	component?: string;
+	path?: string;
+	assoc_id?: number;
+};
+
+type NativeQueryResult = {
+	subBrowseActive: boolean;
+	item: BrowseResult | null;
+};
+
+const IS_MAC = navigator.platform.toLowerCase().includes("mac");
+const INPUT_ID = "ui_browser_input_page_charts_settings";
+const BROWSER_ID = "page_charts_settings";
+const NATIVE_QUERY_EVENT = "EbrChartBrowserFirstMatchEvent";
+const RYMCHART_PATCH_ATTEMPTS = 20;
+const RYMCHART_PATCH_INTERVAL_MS = 200;
+const SHORTCUT_SECTION_SELECTOR = ".page_chart_query_free_section_new";
+const SHORTCUT_LABEL_SELECTOR = ".page_chart_query_free_section_label";
+const HINT_TOGGLE_STYLE = `
+	.ebr-hint-toggle {
+		cursor: pointer;
+	}
+	.ebr-hint-toggle:hover {
+		text-decoration: underline;
+	}
+`;
+
+const APPLY_KEY_CATEGORY: Record<string, Category> = {
+	"1": "genre",
+	"2": "sec_genre",
+	"3": "genre_either",
+	d: "descriptor",
+};
+
+const SUB_TOGGLE_KEY_CATEGORY: Record<string, Category> = {
+	z: "genre",
+	x: "sec_genre",
+	c: "genre_either",
+	s: "descriptor",
+};
+
+const ALL_TOGGLE_KEY_CATEGORY: Record<string, Category> = {
+	q: "genre",
+	w: "sec_genre",
+	e: "genre_either",
+	a: "descriptor",
+};
+
+const APPLY_SCOPE: Record<Category, Scope> = {
+	genre: "genre",
+	sec_genre: "genre",
+	genre_either: "genre",
+	descriptor: "descriptor",
+};
+
+const ADVANCED_USER_TOGGLE: Record<string, AdvancedToggle> = {
+	f: {
+		id: "page_chart_query_advanced_users_following",
+		handler: "onClickUsersFollowing",
+	},
+	v: {
+		id: "page_chart_query_advanced_users_followers",
+		handler: "onClickUsersFollowers",
+	},
+	r: {
+		id: "page_chart_query_advanced_users_self",
+		handler: "onClickUsersSelf",
+	},
+};
+
+const ADVANCED_EXCLUDE_TOGGLE: Record<string, AdvancedToggle> = {
+	r: {
+		id: "page_chart_query_advanced_exclude_label_ratings",
+		handler: "onClickExcludeCatRatings",
+	},
+	f: {
+		id: "page_chart_query_advanced_exclude_label_catalog",
+		handler: "onClickExcludeCatCatalog",
+	},
+	v: {
+		id: "page_chart_query_advanced_exclude_label_wishlist",
+		handler: "onClickExcludeCatWishlist",
+	},
+};
+
+const MODIFIER_LABEL = IS_MAC ? "control" : "alt";
+
+const HINT_LINES = [
+	`${MODIFIER_LABEL} + 1 — include first genre result as "genre"`,
+	`${MODIFIER_LABEL} + 2 — include first genre result as "influence"`,
+	`${MODIFIER_LABEL} + 3 — include first genre result as "either"`,
+	`${MODIFIER_LABEL} + d — include first descriptor result as "descriptor"\n`,
+
+	`${MODIFIER_LABEL} + shift + 1 — exclude first genre result as "genre"`,
+	`${MODIFIER_LABEL} + shift + 2 — exclude first genre result as "influence"`,
+	`${MODIFIER_LABEL} + shift + 3 — exclude first genre result as "either"`,
+	`${MODIFIER_LABEL} + shift + d — exclude first descriptor result as "descriptor"\n`,
+
+	`${MODIFIER_LABEL} + z — toggle "Include sub-genres" for "genres"`,
+	`${MODIFIER_LABEL} + x — toggle "Include sub-genres" for "influences"`,
+	`${MODIFIER_LABEL} + c — toggle "Include sub-genres" for "either"`,
+	`${MODIFIER_LABEL} + s — toggle "Include sub-genres" for "descriptors"\n`,
+
+	`${MODIFIER_LABEL} + shift + z — toggle "Exclude sub-genres" for "genres"`,
+	`${MODIFIER_LABEL} + shift + x — toggle "Exclude sub-genres" for "influences"`,
+	`${MODIFIER_LABEL} + shift + c — toggle "Exclude sub-genres" for "either"`,
+	`${MODIFIER_LABEL} + shift + s — toggle "Exclude sub-genres" for "descriptors"\n`,
+
+	`${MODIFIER_LABEL} + q — toggle "Must contain all" for "genres"`,
+	`${MODIFIER_LABEL} + w — toggle "Must contain all" for "influences"`,
+	`${MODIFIER_LABEL} + e — toggle "Must contain all" for "either"`,
+	`${MODIFIER_LABEL} + a — toggle "Must contain all" for "descriptors"\n`,
+
+	`${MODIFIER_LABEL} + shift + q — toggle "Only exclude items containing all" for "genres"`,
+	`${MODIFIER_LABEL} + shift + w — toggle "Only exclude items containing all" for "influences"`,
+	`${MODIFIER_LABEL} + shift + e — toggle "Only exclude items containing all" for "either"`,
+	`${MODIFIER_LABEL} + shift + a — toggle "Only exclude items containing all" for "descriptors"\n`,
+
+	`${MODIFIER_LABEL} + r — toggle "Only include ratings from myself"`,
+	`${MODIFIER_LABEL} + f — toggle "Only include ratings from users I'm following"`,
+	`${MODIFIER_LABEL} + v — toggle "Only include ratings from users who follow me"\n`,
+
+	`${MODIFIER_LABEL} + shift + r — toggle "Exclude releases I've rated"`,
+	`${MODIFIER_LABEL} + shift + f — toggle "Exclude releases I've cataloged"`,
+	`${MODIFIER_LABEL} + shift + v — toggle "Exclude releases I've wishlisted"\n`,
+
+	`${MODIFIER_LABEL} + space — "Update chart"`,
+	`${MODIFIER_LABEL} + enter — "Update chart"`,
+];
+
+export async function main(): Promise<void> {
+	const input = await waitForElement<HTMLInputElement>(`#${INPUT_ID}`);
+	mount(input);
+}
+
+function filterTypeFor(category: Category, exclude: boolean): FilterType {
+	return `${category}_${exclude ? "exclude" : "include"}` as FilterType;
+}
+
+function itemId(item: BrowseResult): number | null {
+	if (item.assoc_id != null) return item.assoc_id;
+	const match = /\/(\d+)$/.exec(item.path ?? "");
+	return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function applyItem(filterType: FilterType, item: BrowseResult): void {
+	const name = item.display_name ?? item.name ?? "";
+	const id = itemId(item);
+	if (!name || id == null) return;
+
+	void runScript(`
+		(function () {
+			var chart = window.RYMchart;
+			if (!chart) return;
+			var originalCreateChart = chart.onClickCreateChart;
+			chart.onClickCreateChart = function () {};
+			try {
+				chart.addBrowserItem(${JSON.stringify(filterType)}, ${id}, ${JSON.stringify(name)});
+			} finally {
+				chart.onClickCreateChart = originalCreateChart;
+			}
+		})();
+	`);
+}
+
+function toggleCheckbox(filterType: FilterType, kind: CheckboxKind): void {
+	const suffix = kind === "sub" ? "sub_items" : "all";
+	const handlerName =
+		kind === "sub" ? "onClickBrowserItemSub" : "onClickBrowserItemAll";
+	const id = `page_chart_query_free_section_${filterType}_${suffix}`;
+
+	void runScript(`
+		(function () {
+			var checkbox = document.getElementById(${JSON.stringify(id)});
+			if (!checkbox) return;
+			checkbox.checked = !checkbox.checked;
+			var chart = window.RYMchart;
+			if (chart && typeof chart.${handlerName} === "function") {
+				chart.${handlerName}(${JSON.stringify(filterType)});
+			}
+		})();
+	`);
+}
+
+function toggleAdvanced(toggle: AdvancedToggle): void {
+	void runScript(`
+		(function () {
+			var checkbox = document.getElementById(${JSON.stringify(toggle.id)});
+			if (!checkbox) return;
+			checkbox.checked = !checkbox.checked;
+			var chart = window.RYMchart;
+			if (chart && typeof chart.${toggle.handler} === "function") {
+				chart.${toggle.handler}();
+			}
+		})();
+	`);
+}
+
+/**
+ * Reads RYM's own native browse-widget state via an injected script rather
+ * than a separate fetch, so shortcuts always match what RYM's own dropdown
+ * would show. Deliberately reads RYMbrowser.resultCache (keyed by the exact
+ * {q, component} that produced it) rather than currentResultSet ("last
+ * rendered", which can be stale relative to the just-typed query if a
+ * shortcut is pressed before RYM's own debounced search round-trip lands) —
+ * a missing cache entry for the current input value means no match yet,
+ * not a wrong one.
+ */
+function queryNativeBrowser(scope: Scope): Promise<NativeQueryResult> {
+	const promise = new Promise<NativeQueryResult>((resolve) => {
+		const listener = (e: Event) => {
+			document.removeEventListener(NATIVE_QUERY_EVENT, listener);
+			resolve((e as CustomEvent).detail as NativeQueryResult);
+		};
+		document.addEventListener(NATIVE_QUERY_EVENT, listener);
+	});
+
+	void runScript(`
+		(function () {
+			var browser = window.RYMbrowser;
+			var id = ${JSON.stringify(BROWSER_ID)};
+			var path = (browser && browser.path && browser.path[id]) || [];
+			var subBrowseActive = path.length > 0;
+			var item = null;
+			if (!subBrowseActive && browser && browser.resultCache) {
+				var input = document.getElementById(${JSON.stringify(INPUT_ID)});
+				var root = document.getElementById("ui_browser_" + id);
+				var query = input ? input.value.trim() : "";
+				var component = root ? root.dataset.component || "" : "";
+				var cacheKey = JSON.stringify({ q: query, component: component });
+				var resultSet = browser.resultCache[cacheKey];
+				var results = (resultSet && resultSet.results) || [];
+				for (var i = 0; i < results.length; i++) {
+					var result = results[i];
+					var resultComponent = result.component || (result.path || "").split("/")[0];
+					if (resultComponent === ${JSON.stringify(scope)}) {
+						item = result;
+						break;
+					}
+				}
+			}
+			document.dispatchEvent(
+				new CustomEvent(${JSON.stringify(NATIVE_QUERY_EVENT)}, {
+					detail: { subBrowseActive: subBrowseActive, item: item },
+				}),
+			);
+		})();
+	`);
+
+	return promise;
+}
+
+async function applyNativeMatch(
+	scope: Scope,
+	filterType: FilterType,
+	input: HTMLInputElement,
+): Promise<void> {
+	const { subBrowseActive, item } = await queryNativeBrowser(scope);
+	if (subBrowseActive || !item) return;
+
+	applyItem(filterType, item);
+	resetInput(input);
+}
+
+function findShortcutLabel(input: HTMLInputElement): HTMLElement | null {
+	const section = input.closest<HTMLElement>(SHORTCUT_SECTION_SELECTOR);
+	return section?.querySelector<HTMLElement>(SHORTCUT_LABEL_SELECTOR) ?? null;
+}
+
+function insertShortcutHint(input: HTMLInputElement): void {
+	const label = findShortcutLabel(input);
+	if (!label || label.dataset.ebrHint) return;
+
+	label.dataset.ebrHint = "1";
+
+	const style = document.createElement("style");
+	style.textContent = HINT_TOGGLE_STYLE;
+	document.head.appendChild(style);
+
+	const hintLines = document.createElement("span");
+	hintLines.style.display = "none";
+	hintLines.innerHTML = `<br>${HINT_LINES.map((line) =>
+		line.replace(/\n/g, "<br>"),
+	).join("<br>")}`;
+
+	const toggle = document.createElement("span");
+	toggle.className = "ebr-hint-toggle";
+	toggle.textContent = "Show shortcut hints";
+
+	toggle.addEventListener("click", (event) => {
+		event.stopPropagation();
+		const isHidden = hintLines.style.display === "none";
+		hintLines.style.display = isHidden ? "" : "none";
+		toggle.textContent = isHidden
+			? "Hide shortcut hints"
+			: "Show shortcut hints";
+	});
+
+	label.append(document.createElement("br"), toggle, hintLines);
+}
+
+function resetInput(input: HTMLInputElement): void {
+	input.value = "";
+}
+
+function updateChart(): void {
+	void runScript(`
+		if (window.RYMchart && typeof window.RYMchart.onClickCreateChart === "function") {
+			window.RYMchart.onClickCreateChart();
+		}
+	`);
+}
+
+function hasShortcutModifier(event: KeyboardEvent): boolean {
+	// AltGr (common on European layouts) reports as altKey+ctrlKey together;
+	// excluding ctrlKey here keeps AltGr character entry from misfiring shortcuts.
+	return IS_MAC ? event.ctrlKey : event.altKey && !event.ctrlKey;
+}
+
+function handleApplyShortcut(
+	event: KeyboardEvent,
+	input: HTMLInputElement,
+): boolean {
+	if (!hasShortcutModifier(event)) return false;
+	const category = APPLY_KEY_CATEGORY[event.key.toLowerCase()];
+	if (!category) return false;
+
+	const filterType = filterTypeFor(category, event.shiftKey);
+	void applyNativeMatch(APPLY_SCOPE[category], filterType, input);
+	return true;
+}
+
+function handleSubToggleShortcut(event: KeyboardEvent): boolean {
+	if (!hasShortcutModifier(event)) return false;
+	const category = SUB_TOGGLE_KEY_CATEGORY[event.key.toLowerCase()];
+	if (!category) return false;
+
+	toggleCheckbox(filterTypeFor(category, event.shiftKey), "sub");
+	return true;
+}
+
+function handleAllToggleShortcut(event: KeyboardEvent): boolean {
+	if (!hasShortcutModifier(event)) return false;
+	const category = ALL_TOGGLE_KEY_CATEGORY[event.key.toLowerCase()];
+	if (!category) return false;
+
+	toggleCheckbox(filterTypeFor(category, event.shiftKey), "all");
+	return true;
+}
+
+function handleAdvancedToggleShortcut(event: KeyboardEvent): boolean {
+	if (!hasShortcutModifier(event)) return false;
+	const table = event.shiftKey ? ADVANCED_EXCLUDE_TOGGLE : ADVANCED_USER_TOGGLE;
+	const toggle = table[event.key.toLowerCase()];
+	if (!toggle) return false;
+
+	toggleAdvanced(toggle);
+	return true;
+}
+
+function handleUpdateChartShortcut(event: KeyboardEvent): boolean {
+	if (
+		(event.key !== "Enter" && event.key !== " ") ||
+		!hasShortcutModifier(event)
+	)
+		return false;
+	updateChart();
+	return true;
+}
+
+const KEY_HANDLERS = [
+	handleApplyShortcut,
+	handleSubToggleShortcut,
+	handleAllToggleShortcut,
+	handleAdvancedToggleShortcut,
+	handleUpdateChartShortcut,
+];
+
+function onKeyDown(event: KeyboardEvent, input: HTMLInputElement): void {
+	for (const handler of KEY_HANDLERS) {
+		if (!handler(event, input)) continue;
+		event.preventDefault();
+		event.stopPropagation();
+		return;
+	}
+}
+
+function isOtherEditableTarget(
+	target: EventTarget | null,
+	input: HTMLInputElement,
+): boolean {
+	if (!(target instanceof HTMLElement) || target === input) return false;
+	return (
+		target.tagName === "INPUT" ||
+		target.tagName === "TEXTAREA" ||
+		target.isContentEditable
+	);
+}
+
+function patchRYMChartRemoval(): void {
+	void runScript(`
+		(function () {
+			var attempts = 0;
+			var interval = setInterval(function () {
+				attempts += 1;
+				if (attempts > ${RYMCHART_PATCH_ATTEMPTS}) {
+					clearInterval(interval);
+					return;
+				}
+				var chart = window.RYMchart;
+				if (!chart || typeof chart.removeBrowserItem !== "function") return;
+				clearInterval(interval);
+				var original = chart.removeBrowserItem.bind(chart);
+				chart.removeBrowserItem = function () {
+					var originalCreateChart = chart.onClickCreateChart;
+					chart.onClickCreateChart = function () {};
+					try {
+						return original.apply(chart, arguments);
+					} finally {
+						chart.onClickCreateChart = originalCreateChart;
+					}
+				};
+			}, ${RYMCHART_PATCH_INTERVAL_MS});
+		})();
+	`);
+}
+
+function mount(input: HTMLInputElement): void {
+	insertShortcutHint(input);
+
+	document.addEventListener(
+		"keydown",
+		(event) => {
+			if (isOtherEditableTarget(event.target, input)) return;
+			onKeyDown(event, input);
+		},
+		true,
+	);
+
+	patchRYMChartRemoval();
+}

--- a/src/modules/chart-shortcuts/app.ts
+++ b/src/modules/chart-shortcuts/app.ts
@@ -1,6 +1,15 @@
+import type {
+	ChartShortcutActionId,
+	ChartShortcutGroup,
+} from "~/shared/chart-shortcuts/actions";
+import { CHART_SHORTCUT_ACTIONS } from "~/shared/chart-shortcuts/actions";
+import type { ChartShortcutBindings } from "~/shared/chart-shortcuts/binding";
+import { comboFromEvent, formatCombo } from "~/shared/chart-shortcuts/binding";
+import {
+	getChartShortcutBindings,
+	subscribeToChartShortcutBindings,
+} from "~/shared/chart-shortcuts/settings";
 import { runScript, waitForElement } from "~/shared/utils/dom";
-
-type Category = "genre" | "sec_genre" | "genre_either" | "descriptor";
 
 type FilterType =
 	| "genre_include"
@@ -34,7 +43,6 @@ type NativeQueryResult = {
 	item: BrowseResult | null;
 };
 
-const IS_MAC = navigator.platform.toLowerCase().includes("mac");
 const INPUT_ID = "ui_browser_input_page_charts_settings";
 const BROWSER_ID = "page_charts_settings";
 const NATIVE_QUERY_EVENT = "EbrChartBrowserFirstMatchEvent";
@@ -51,116 +59,88 @@ const HINT_TOGGLE_STYLE = `
 	}
 `;
 
-const APPLY_KEY_CATEGORY: Record<string, Category> = {
-	"1": "genre",
-	"2": "sec_genre",
-	"3": "genre_either",
-	d: "descriptor",
+const ACTION_EFFECTS: Record<
+	ChartShortcutActionId,
+	(input: HTMLInputElement) => void
+> = {
+	includeGenre: (input) =>
+		void applyNativeMatch("genre", "genre_include", input),
+	includeInfluence: (input) =>
+		void applyNativeMatch("genre", "sec_genre_include", input),
+	includeEither: (input) =>
+		void applyNativeMatch("genre", "genre_either_include", input),
+	includeDescriptor: (input) =>
+		void applyNativeMatch("descriptor", "descriptor_include", input),
+	excludeGenre: (input) =>
+		void applyNativeMatch("genre", "genre_exclude", input),
+	excludeInfluence: (input) =>
+		void applyNativeMatch("genre", "sec_genre_exclude", input),
+	excludeEither: (input) =>
+		void applyNativeMatch("genre", "genre_either_exclude", input),
+	excludeDescriptor: (input) =>
+		void applyNativeMatch("descriptor", "descriptor_exclude", input),
+
+	toggleSubGenreInclude: () => toggleCheckbox("genre_include", "sub"),
+	toggleSubInfluenceInclude: () => toggleCheckbox("sec_genre_include", "sub"),
+	toggleSubEitherInclude: () => toggleCheckbox("genre_either_include", "sub"),
+	toggleSubDescriptorInclude: () => toggleCheckbox("descriptor_include", "sub"),
+	toggleSubGenreExclude: () => toggleCheckbox("genre_exclude", "sub"),
+	toggleSubInfluenceExclude: () => toggleCheckbox("sec_genre_exclude", "sub"),
+	toggleSubEitherExclude: () => toggleCheckbox("genre_either_exclude", "sub"),
+	toggleSubDescriptorExclude: () => toggleCheckbox("descriptor_exclude", "sub"),
+
+	toggleAllGenreInclude: () => toggleCheckbox("genre_include", "all"),
+	toggleAllInfluenceInclude: () => toggleCheckbox("sec_genre_include", "all"),
+	toggleAllEitherInclude: () => toggleCheckbox("genre_either_include", "all"),
+	toggleAllDescriptorInclude: () => toggleCheckbox("descriptor_include", "all"),
+	toggleAllGenreExclude: () => toggleCheckbox("genre_exclude", "all"),
+	toggleAllInfluenceExclude: () => toggleCheckbox("sec_genre_exclude", "all"),
+	toggleAllEitherExclude: () => toggleCheckbox("genre_either_exclude", "all"),
+	toggleAllDescriptorExclude: () => toggleCheckbox("descriptor_exclude", "all"),
+
+	onlyRatingsSelf: () =>
+		toggleAdvanced({
+			id: "page_chart_query_advanced_users_self",
+			handler: "onClickUsersSelf",
+		}),
+	onlyRatingsFollowing: () =>
+		toggleAdvanced({
+			id: "page_chart_query_advanced_users_following",
+			handler: "onClickUsersFollowing",
+		}),
+	onlyRatingsFollowers: () =>
+		toggleAdvanced({
+			id: "page_chart_query_advanced_users_followers",
+			handler: "onClickUsersFollowers",
+		}),
+
+	excludeRated: () =>
+		toggleAdvanced({
+			id: "page_chart_query_advanced_exclude_label_ratings",
+			handler: "onClickExcludeCatRatings",
+		}),
+	excludeCataloged: () =>
+		toggleAdvanced({
+			id: "page_chart_query_advanced_exclude_label_catalog",
+			handler: "onClickExcludeCatCatalog",
+		}),
+	excludeWishlisted: () =>
+		toggleAdvanced({
+			id: "page_chart_query_advanced_exclude_label_wishlist",
+			handler: "onClickExcludeCatWishlist",
+		}),
+
+	updateChart: () => updateChart(),
 };
 
-const SUB_TOGGLE_KEY_CATEGORY: Record<string, Category> = {
-	z: "genre",
-	x: "sec_genre",
-	c: "genre_either",
-	s: "descriptor",
-};
-
-const ALL_TOGGLE_KEY_CATEGORY: Record<string, Category> = {
-	q: "genre",
-	w: "sec_genre",
-	e: "genre_either",
-	a: "descriptor",
-};
-
-const APPLY_SCOPE: Record<Category, Scope> = {
-	genre: "genre",
-	sec_genre: "genre",
-	genre_either: "genre",
-	descriptor: "descriptor",
-};
-
-const ADVANCED_USER_TOGGLE: Record<string, AdvancedToggle> = {
-	f: {
-		id: "page_chart_query_advanced_users_following",
-		handler: "onClickUsersFollowing",
-	},
-	v: {
-		id: "page_chart_query_advanced_users_followers",
-		handler: "onClickUsersFollowers",
-	},
-	r: {
-		id: "page_chart_query_advanced_users_self",
-		handler: "onClickUsersSelf",
-	},
-};
-
-const ADVANCED_EXCLUDE_TOGGLE: Record<string, AdvancedToggle> = {
-	r: {
-		id: "page_chart_query_advanced_exclude_label_ratings",
-		handler: "onClickExcludeCatRatings",
-	},
-	f: {
-		id: "page_chart_query_advanced_exclude_label_catalog",
-		handler: "onClickExcludeCatCatalog",
-	},
-	v: {
-		id: "page_chart_query_advanced_exclude_label_wishlist",
-		handler: "onClickExcludeCatWishlist",
-	},
-};
-
-const MODIFIER_LABEL = IS_MAC ? "control" : "alt";
-
-const HINT_LINES = [
-	`${MODIFIER_LABEL} + 1 — include first genre result as "genre"`,
-	`${MODIFIER_LABEL} + 2 — include first genre result as "influence"`,
-	`${MODIFIER_LABEL} + 3 — include first genre result as "either"`,
-	`${MODIFIER_LABEL} + d — include first descriptor result as "descriptor"\n`,
-
-	`${MODIFIER_LABEL} + shift + 1 — exclude first genre result as "genre"`,
-	`${MODIFIER_LABEL} + shift + 2 — exclude first genre result as "influence"`,
-	`${MODIFIER_LABEL} + shift + 3 — exclude first genre result as "either"`,
-	`${MODIFIER_LABEL} + shift + d — exclude first descriptor result as "descriptor"\n`,
-
-	`${MODIFIER_LABEL} + z — toggle "Include sub-genres" for "genres"`,
-	`${MODIFIER_LABEL} + x — toggle "Include sub-genres" for "influences"`,
-	`${MODIFIER_LABEL} + c — toggle "Include sub-genres" for "either"`,
-	`${MODIFIER_LABEL} + s — toggle "Include sub-genres" for "descriptors"\n`,
-
-	`${MODIFIER_LABEL} + shift + z — toggle "Exclude sub-genres" for "genres"`,
-	`${MODIFIER_LABEL} + shift + x — toggle "Exclude sub-genres" for "influences"`,
-	`${MODIFIER_LABEL} + shift + c — toggle "Exclude sub-genres" for "either"`,
-	`${MODIFIER_LABEL} + shift + s — toggle "Exclude sub-genres" for "descriptors"\n`,
-
-	`${MODIFIER_LABEL} + q — toggle "Must contain all" for "genres"`,
-	`${MODIFIER_LABEL} + w — toggle "Must contain all" for "influences"`,
-	`${MODIFIER_LABEL} + e — toggle "Must contain all" for "either"`,
-	`${MODIFIER_LABEL} + a — toggle "Must contain all" for "descriptors"\n`,
-
-	`${MODIFIER_LABEL} + shift + q — toggle "Only exclude items containing all" for "genres"`,
-	`${MODIFIER_LABEL} + shift + w — toggle "Only exclude items containing all" for "influences"`,
-	`${MODIFIER_LABEL} + shift + e — toggle "Only exclude items containing all" for "either"`,
-	`${MODIFIER_LABEL} + shift + a — toggle "Only exclude items containing all" for "descriptors"\n`,
-
-	`${MODIFIER_LABEL} + r — toggle "Only include ratings from myself"`,
-	`${MODIFIER_LABEL} + f — toggle "Only include ratings from users I'm following"`,
-	`${MODIFIER_LABEL} + v — toggle "Only include ratings from users who follow me"\n`,
-
-	`${MODIFIER_LABEL} + shift + r — toggle "Exclude releases I've rated"`,
-	`${MODIFIER_LABEL} + shift + f — toggle "Exclude releases I've cataloged"`,
-	`${MODIFIER_LABEL} + shift + v — toggle "Exclude releases I've wishlisted"\n`,
-
-	`${MODIFIER_LABEL} + space — "Update chart"`,
-	`${MODIFIER_LABEL} + enter — "Update chart"`,
-];
+let comboToAction = new Map<string, ChartShortcutActionId>();
 
 export async function main(): Promise<void> {
-	const input = await waitForElement<HTMLInputElement>(`#${INPUT_ID}`);
-	mount(input);
-}
-
-function filterTypeFor(category: Category, exclude: boolean): FilterType {
-	return `${category}_${exclude ? "exclude" : "include"}` as FilterType;
+	const [input, bindings] = await Promise.all([
+		waitForElement<HTMLInputElement>(`#${INPUT_ID}`),
+		getChartShortcutBindings(),
+	]);
+	mount(input, bindings);
 }
 
 function itemId(item: BrowseResult): number | null {
@@ -228,7 +208,7 @@ function toggleAdvanced(toggle: AdvancedToggle): void {
  * would show. Deliberately reads RYMbrowser.resultCache (keyed by the exact
  * {q, component} that produced it) rather than currentResultSet ("last
  * rendered", which can be stale relative to the just-typed query if a
- * shortcut is pressed before RYM's own debounced search round-trip lands) —
+ * shortcut is pressed before RYM's own debounced search round-trip lands) -
  * a missing cache entry for the current input value means no match yet,
  * not a wrong one.
  */
@@ -293,9 +273,30 @@ function findShortcutLabel(input: HTMLInputElement): HTMLElement | null {
 	return section?.querySelector<HTMLElement>(SHORTCUT_LABEL_SELECTOR) ?? null;
 }
 
-function insertShortcutHint(input: HTMLInputElement): void {
+function renderHintLines(bindings: ChartShortcutBindings): string {
+	const groups = new Map<ChartShortcutGroup, string[]>();
+
+	for (const action of CHART_SHORTCUT_ACTIONS) {
+		const combos = bindings[action.id];
+		if (combos.length === 0) continue;
+
+		const comboLabel = combos.map((combo) => formatCombo(combo)).join(" or ");
+		const lines = groups.get(action.group) ?? [];
+		lines.push(`${comboLabel} — ${action.hint}`);
+		groups.set(action.group, lines);
+	}
+
+	return [...groups.values()]
+		.map((lines) => lines.join("<br>"))
+		.join("<br><br>");
+}
+
+function insertShortcutHint(
+	input: HTMLInputElement,
+	bindings: ChartShortcutBindings,
+): HTMLElement | null {
 	const label = findShortcutLabel(input);
-	if (!label || label.dataset.ebrHint) return;
+	if (!label || label.dataset.ebrHint) return null;
 
 	label.dataset.ebrHint = "1";
 
@@ -305,9 +306,7 @@ function insertShortcutHint(input: HTMLInputElement): void {
 
 	const hintLines = document.createElement("span");
 	hintLines.style.display = "none";
-	hintLines.innerHTML = `<br>${HINT_LINES.map((line) =>
-		line.replace(/\n/g, "<br>"),
-	).join("<br>")}`;
+	hintLines.innerHTML = `<br>${renderHintLines(bindings)}`;
 
 	const toggle = document.createElement("span");
 	toggle.className = "ebr-hint-toggle";
@@ -323,6 +322,7 @@ function insertShortcutHint(input: HTMLInputElement): void {
 	});
 
 	label.append(document.createElement("br"), toggle, hintLines);
+	return hintLines;
 }
 
 function resetInput(input: HTMLInputElement): void {
@@ -337,78 +337,26 @@ function updateChart(): void {
 	`);
 }
 
-function hasShortcutModifier(event: KeyboardEvent): boolean {
-	// AltGr (common on European layouts) reports as altKey+ctrlKey together;
-	// excluding ctrlKey here keeps AltGr character entry from misfiring shortcuts.
-	return IS_MAC ? event.ctrlKey : event.altKey && !event.ctrlKey;
+function buildComboToAction(
+	bindings: ChartShortcutBindings,
+): Map<string, ChartShortcutActionId> {
+	const map = new Map<string, ChartShortcutActionId>();
+	for (const [actionId, combos] of Object.entries(bindings) as [
+		ChartShortcutActionId,
+		string[],
+	][]) {
+		for (const combo of combos) map.set(combo, actionId);
+	}
+	return map;
 }
-
-function handleApplyShortcut(
-	event: KeyboardEvent,
-	input: HTMLInputElement,
-): boolean {
-	if (!hasShortcutModifier(event)) return false;
-	const category = APPLY_KEY_CATEGORY[event.key.toLowerCase()];
-	if (!category) return false;
-
-	const filterType = filterTypeFor(category, event.shiftKey);
-	void applyNativeMatch(APPLY_SCOPE[category], filterType, input);
-	return true;
-}
-
-function handleSubToggleShortcut(event: KeyboardEvent): boolean {
-	if (!hasShortcutModifier(event)) return false;
-	const category = SUB_TOGGLE_KEY_CATEGORY[event.key.toLowerCase()];
-	if (!category) return false;
-
-	toggleCheckbox(filterTypeFor(category, event.shiftKey), "sub");
-	return true;
-}
-
-function handleAllToggleShortcut(event: KeyboardEvent): boolean {
-	if (!hasShortcutModifier(event)) return false;
-	const category = ALL_TOGGLE_KEY_CATEGORY[event.key.toLowerCase()];
-	if (!category) return false;
-
-	toggleCheckbox(filterTypeFor(category, event.shiftKey), "all");
-	return true;
-}
-
-function handleAdvancedToggleShortcut(event: KeyboardEvent): boolean {
-	if (!hasShortcutModifier(event)) return false;
-	const table = event.shiftKey ? ADVANCED_EXCLUDE_TOGGLE : ADVANCED_USER_TOGGLE;
-	const toggle = table[event.key.toLowerCase()];
-	if (!toggle) return false;
-
-	toggleAdvanced(toggle);
-	return true;
-}
-
-function handleUpdateChartShortcut(event: KeyboardEvent): boolean {
-	if (
-		(event.key !== "Enter" && event.key !== " ") ||
-		!hasShortcutModifier(event)
-	)
-		return false;
-	updateChart();
-	return true;
-}
-
-const KEY_HANDLERS = [
-	handleApplyShortcut,
-	handleSubToggleShortcut,
-	handleAllToggleShortcut,
-	handleAdvancedToggleShortcut,
-	handleUpdateChartShortcut,
-];
 
 function onKeyDown(event: KeyboardEvent, input: HTMLInputElement): void {
-	for (const handler of KEY_HANDLERS) {
-		if (!handler(event, input)) continue;
-		event.preventDefault();
-		event.stopPropagation();
-		return;
-	}
+	const actionId = comboToAction.get(comboFromEvent(event));
+	if (!actionId) return;
+
+	event.preventDefault();
+	event.stopPropagation();
+	ACTION_EFFECTS[actionId](input);
 }
 
 function isOtherEditableTarget(
@@ -451,8 +399,19 @@ function patchRYMChartRemoval(): void {
 	`);
 }
 
-function mount(input: HTMLInputElement): void {
-	insertShortcutHint(input);
+function mount(
+	input: HTMLInputElement,
+	initialBindings: ChartShortcutBindings,
+): void {
+	const hintLines = insertShortcutHint(input, initialBindings);
+	comboToAction = buildComboToAction(initialBindings);
+
+	// Keeps an already-open chart page in sync with a rebind made in the
+	// popup, without requiring a page refresh.
+	subscribeToChartShortcutBindings((bindings) => {
+		comboToAction = buildComboToAction(bindings);
+		if (hintLines) hintLines.innerHTML = `<br>${renderHintLines(bindings)}`;
+	});
 
 	document.addEventListener(
 		"keydown",

--- a/src/modules/chart-shortcuts/main.ts
+++ b/src/modules/chart-shortcuts/main.ts
@@ -1,0 +1,7 @@
+import { runPage } from "~/shared/page-settings";
+
+import { main } from "./app";
+
+await runPage("chartShortcuts", async () => {
+	await main();
+});

--- a/src/modules/popup/app.tsx
+++ b/src/modules/popup/app.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import browser from "webextension-polyfill";
 
@@ -6,7 +5,11 @@ import { getPageEnabled, setPageEnabled } from "~/shared/page-settings";
 import type { PageKey } from "~/shared/pages";
 import { pageGroupLabels, pageHints, pageLabels, pages } from "~/shared/pages";
 
+import { ShortcutView } from "./shortcut-view";
+import { styles } from "./styles";
+
 type FeatureState = Record<PageKey, boolean>;
+type View = "features" | "chartShortcuts";
 
 function buildGroups(): [string, PageKey[]][] {
 	const map = new Map<string, PageKey[]>();
@@ -21,6 +24,7 @@ function buildGroups(): [string, PageKey[]][] {
 const groups = buildGroups();
 
 export function App() {
+	const [view, setView] = useState<View>("features");
 	const [features, setFeatures] = useState<FeatureState | null>(null);
 
 	useEffect(() => {
@@ -45,55 +49,84 @@ export function App() {
 	return (
 		<div style={styles.root}>
 			<header style={styles.header}>
-				<img
-					src={browser.runtime.getURL("icons/sonemic-48.png")}
-					width={28}
-					height={28}
-					alt=""
-					style={styles.logo}
-				/>
+				{view === "chartShortcuts" ? (
+					<button
+						type="button"
+						onClick={() => setView("features")}
+						style={styles.backButton}
+					>
+						← Back
+					</button>
+				) : (
+					<img
+						src={browser.runtime.getURL("icons/sonemic-48.png")}
+						width={28}
+						height={28}
+						alt=""
+						style={styles.logo}
+					/>
+				)}
 				<div>
-					<div style={styles.title}>EvenBetterRYM</div>
-					<div style={styles.subtitle}>RateYourMusic Enhancements</div>
+					<div style={styles.title}>
+						{view === "chartShortcuts" ? "Chart Shortcuts" : "EvenBetterRYM"}
+					</div>
+					<div style={styles.subtitle}>
+						{view === "chartShortcuts"
+							? "Customize keyboard shortcuts"
+							: "RateYourMusic Enhancements"}
+					</div>
 				</div>
 			</header>
 
-			<main style={styles.list}>
-				{features === null ? (
-					<div style={styles.loading}>Loading…</div>
-				) : (
-					groups.map(([path, keys]) => {
-						const isGroup = keys.length > 1;
-						return (
-							<div key={path} style={isGroup ? styles.card : styles.cardFlat}>
-								{isGroup && (
-									<div style={styles.groupHeader}>
-										{pageGroupLabels[path] ?? path}
-									</div>
-								)}
-								{keys.map((key, i) => (
-									<label
-										key={key}
-										style={{
-											...styles.row,
-											...(i < keys.length - 1 ? styles.rowDivider : {}),
-										}}
-									>
-										<span style={styles.label}>
-											{pageLabels[key]}
-											<span class="ebr-hint">{pageHints[key]}</span>
-										</span>
-										<Toggle
-											checked={features[key]}
-											onChange={() => void toggle(key)}
-										/>
-									</label>
-								))}
-							</div>
-						);
-					})
-				)}
-			</main>
+			{view === "chartShortcuts" ? (
+				<ShortcutView />
+			) : (
+				<main style={styles.list}>
+					{features === null ? (
+						<div style={styles.loading}>Loading…</div>
+					) : (
+						groups.map(([path, keys]) => {
+							const isGroup = keys.length > 1;
+							return (
+								<div key={path} style={isGroup ? styles.card : styles.cardFlat}>
+									{isGroup && (
+										<div style={styles.groupHeader}>
+											{pageGroupLabels[path] ?? path}
+										</div>
+									)}
+									{keys.map((key, i) => (
+										<label
+											key={key}
+											style={{
+												...styles.row,
+												...(i < keys.length - 1 ? styles.rowDivider : {}),
+											}}
+										>
+											<span style={styles.label}>
+												{pageLabels[key]}
+												<span class="ebr-hint">{pageHints[key]}</span>
+											</span>
+											{key === "chartShortcuts" && (
+												<button
+													type="button"
+													onClick={() => setView("chartShortcuts")}
+													style={styles.customizeButton}
+												>
+													Customize shortcuts
+												</button>
+											)}
+											<Toggle
+												checked={features[key]}
+												onChange={() => void toggle(key)}
+											/>
+										</label>
+									))}
+								</div>
+							);
+						})
+					)}
+				</main>
+			)}
 		</div>
 	);
 }
@@ -125,124 +158,3 @@ function Toggle({
 		</button>
 	);
 }
-
-const styles = {
-	root: {
-		width: 340,
-		fontFamily:
-			'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-		fontSize: 13,
-		color: "#1a1a1a",
-		background: "#f2f2f2",
-	} satisfies CSSProperties,
-
-	header: {
-		display: "flex",
-		alignItems: "center",
-		gap: 10,
-		padding: "14px 16px",
-		background: "#1c1c1c",
-		color: "#fff",
-	} satisfies CSSProperties,
-
-	logo: {
-		borderRadius: 6,
-		flexShrink: 0,
-	} satisfies CSSProperties,
-
-	title: {
-		fontWeight: 700,
-		fontSize: 14,
-		color: "#fff",
-		lineHeight: 1.3,
-	} satisfies CSSProperties,
-
-	subtitle: {
-		fontSize: 11,
-		color: "#888",
-		lineHeight: 1.3,
-	} satisfies CSSProperties,
-
-	list: {
-		display: "flex",
-		flexDirection: "column",
-		gap: 1,
-		padding: "10px 10px",
-	} satisfies CSSProperties,
-
-	card: {
-		background: "#fff",
-		borderRadius: 8,
-		overflow: "hidden",
-		boxShadow: "0 1px 3px rgba(0,0,0,0.07)",
-	} satisfies CSSProperties,
-
-	cardFlat: {
-		background: "#fff",
-		borderRadius: 8,
-		overflow: "hidden",
-		boxShadow: "0 1px 3px rgba(0,0,0,0.07)",
-	} satisfies CSSProperties,
-
-	groupHeader: {
-		padding: "7px 12px 6px",
-		fontSize: 10,
-		fontWeight: 700,
-		textTransform: "uppercase" as const,
-		letterSpacing: "0.08em",
-		color: "#4286c4",
-		background: "#f0f6fc",
-		borderBottom: "1px solid #d8eaf7",
-	} satisfies CSSProperties,
-
-	row: {
-		display: "flex",
-		alignItems: "center",
-		justifyContent: "space-between",
-		padding: "10px 12px",
-		cursor: "pointer",
-		userSelect: "none" as const,
-	} satisfies CSSProperties,
-
-	rowDivider: {
-		borderBottom: "1px solid #f0f0f0",
-	} satisfies CSSProperties,
-
-	label: {
-		flex: 1,
-		paddingRight: 12,
-		lineHeight: 1.45,
-		color: "#2a2a2a",
-	} satisfies CSSProperties,
-
-	loading: {
-		padding: "20px 16px",
-		color: "#999",
-		textAlign: "center" as const,
-	} satisfies CSSProperties,
-
-	toggle: {
-		position: "relative",
-		flexShrink: 0,
-		width: 40,
-		height: 22,
-		border: "none",
-		borderRadius: 11,
-		cursor: "pointer",
-		padding: 0,
-		transition: "background 0.2s",
-	} satisfies CSSProperties,
-
-	thumb: {
-		position: "absolute",
-		top: 2,
-		left: 0,
-		width: 18,
-		height: 18,
-		borderRadius: "50%",
-		background: "#fff",
-		boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
-		transition: "transform 0.2s",
-		display: "block",
-	} satisfies CSSProperties,
-};

--- a/src/modules/popup/shortcut-recorder.tsx
+++ b/src/modules/popup/shortcut-recorder.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+
+import {
+	comboFromEvent,
+	hasRequiredModifier,
+	isMacPlatform,
+	isModifierOnlyCode,
+} from "~/shared/chart-shortcuts/binding";
+
+import { styles } from "./styles";
+
+const NEEDS_MODIFIER_MESSAGE = `Shortcuts need ${isMacPlatform ? "Control" : "Ctrl"}, ${isMacPlatform ? "Option" : "Alt"}, or Command`;
+
+type ShortcutRecorderProps = Readonly<{
+	// Returns an error message to display, or null once the combo is saved.
+	onCapture: (combo: string) => string | null;
+}>;
+
+export function ShortcutRecorder({ onCapture }: ShortcutRecorderProps) {
+	const [recording, setRecording] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const startRecording = () => {
+		setError(null);
+		setRecording(true);
+	};
+
+	// Focusing imperatively (rather than the autoFocus prop, which biome's
+	// a11y rule flags) - this field only appears after a direct click on the
+	// "+" button, so the focus jump is user-initiated, not a surprise.
+	useEffect(() => {
+		if (recording) inputRef.current?.focus();
+	}, [recording]);
+
+	if (!recording) {
+		return (
+			<button type="button" onClick={startRecording} style={styles.addButton}>
+				+
+			</button>
+		);
+	}
+
+	return (
+		<>
+			<input
+				ref={inputRef}
+				readOnly
+				value="Press keys… (Esc to cancel)"
+				style={styles.recorderInput}
+				onBlur={() => setRecording(false)}
+				onKeyDown={(event) => {
+					event.preventDefault();
+					event.stopPropagation();
+
+					if (event.key === "Escape") {
+						setRecording(false);
+						return;
+					}
+					if (isModifierOnlyCode(event.code)) return;
+
+					const combo = comboFromEvent(event);
+					if (!hasRequiredModifier(combo)) {
+						setError(NEEDS_MODIFIER_MESSAGE);
+						return;
+					}
+
+					const captureError = onCapture(combo);
+					if (captureError) {
+						setError(captureError);
+						return;
+					}
+
+					setRecording(false);
+					setError(null);
+				}}
+			/>
+			{error && <div style={styles.comboError}>{error}</div>}
+		</>
+	);
+}

--- a/src/modules/popup/shortcut-view.tsx
+++ b/src/modules/popup/shortcut-view.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "preact/hooks";
+
+import type { ChartShortcutActionId } from "~/shared/chart-shortcuts/actions";
+import {
+	CHART_SHORTCUT_ACTIONS,
+	CHART_SHORTCUT_GROUP_LABELS,
+} from "~/shared/chart-shortcuts/actions";
+import type { ChartShortcutBindings } from "~/shared/chart-shortcuts/binding";
+import {
+	findComboConflict,
+	formatCombo,
+} from "~/shared/chart-shortcuts/binding";
+import {
+	defaultBindings,
+	getChartShortcutBindings,
+	setChartShortcutBindings,
+} from "~/shared/chart-shortcuts/settings";
+import { groupBy } from "~/shared/utils/array";
+
+import { ShortcutRecorder } from "./shortcut-recorder";
+import { styles } from "./styles";
+
+const groups = groupBy(CHART_SHORTCUT_ACTIONS, (action) => action.group);
+
+function labelFor(actionId: ChartShortcutActionId): string {
+	return (
+		CHART_SHORTCUT_ACTIONS.find((action) => action.id === actionId)?.label ??
+		actionId
+	);
+}
+
+export function ShortcutView() {
+	const [bindings, setBindings] = useState<ChartShortcutBindings | null>(null);
+
+	useEffect(() => {
+		void getChartShortcutBindings().then(setBindings);
+	}, []);
+
+	const save = async (next: ChartShortcutBindings) => {
+		setBindings(next);
+		await setChartShortcutBindings(next);
+	};
+
+	const removeCombo = (actionId: ChartShortcutActionId, combo: string) => {
+		if (!bindings) return;
+		void save({
+			...bindings,
+			[actionId]: bindings[actionId].filter((existing) => existing !== combo),
+		});
+	};
+
+	const addCombo = (
+		actionId: ChartShortcutActionId,
+		combo: string,
+	): string | null => {
+		if (!bindings) return "Not ready yet";
+
+		if (bindings[actionId].includes(combo)) {
+			return "Already added to this shortcut";
+		}
+
+		const conflict = findComboConflict(bindings, combo, actionId);
+		if (conflict) {
+			return `Already used by "${labelFor(conflict)}"`;
+		}
+
+		void save({ ...bindings, [actionId]: [...bindings[actionId], combo] });
+		return null;
+	};
+
+	const resetAll = () => {
+		void save(defaultBindings());
+	};
+
+	if (!bindings) {
+		return <div style={styles.loading}>Loading…</div>;
+	}
+
+	return (
+		<main style={styles.list}>
+			{groups.map(([group, actions]) => (
+				<div key={group} style={styles.card}>
+					<div style={styles.groupHeader}>
+						{CHART_SHORTCUT_GROUP_LABELS[group]}
+					</div>
+					{actions.map((action, i) => (
+						<div
+							key={action.id}
+							style={{
+								...styles.shortcutRow,
+								...(i < actions.length - 1 ? styles.rowDivider : {}),
+							}}
+						>
+							<span style={styles.shortcutLabel}>{action.label}</span>
+							<div style={styles.comboRow}>
+								{bindings[action.id].map((combo) => (
+									<span key={combo} style={styles.chip}>
+										{formatCombo(combo)}
+										<button
+											type="button"
+											aria-label={`Remove ${formatCombo(combo)}`}
+											onClick={() => removeCombo(action.id, combo)}
+											style={styles.chipRemove}
+										>
+											×
+										</button>
+									</span>
+								))}
+								<ShortcutRecorder
+									onCapture={(combo) => addCombo(action.id, combo)}
+								/>
+							</div>
+						</div>
+					))}
+				</div>
+			))}
+
+			<div style={styles.resetRow}>
+				<button type="button" onClick={resetAll} style={styles.resetButton}>
+					Reset all to defaults
+				</button>
+			</div>
+		</main>
+	);
+}

--- a/src/modules/popup/styles.ts
+++ b/src/modules/popup/styles.ts
@@ -1,0 +1,234 @@
+import type { CSSProperties } from "preact";
+
+export const styles = {
+	root: {
+		width: 340,
+		fontFamily:
+			'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+		fontSize: 13,
+		color: "#1a1a1a",
+		background: "#f2f2f2",
+	} satisfies CSSProperties,
+
+	header: {
+		display: "flex",
+		alignItems: "center",
+		gap: 10,
+		padding: "14px 16px",
+		background: "#1c1c1c",
+		color: "#fff",
+	} satisfies CSSProperties,
+
+	logo: {
+		borderRadius: 6,
+		flexShrink: 0,
+	} satisfies CSSProperties,
+
+	title: {
+		fontWeight: 700,
+		fontSize: 14,
+		color: "#fff",
+		lineHeight: 1.3,
+	} satisfies CSSProperties,
+
+	subtitle: {
+		fontSize: 11,
+		color: "#888",
+		lineHeight: 1.3,
+	} satisfies CSSProperties,
+
+	list: {
+		display: "flex",
+		flexDirection: "column",
+		gap: 1,
+		padding: "10px 10px",
+	} satisfies CSSProperties,
+
+	card: {
+		background: "#fff",
+		borderRadius: 8,
+		overflow: "hidden",
+		boxShadow: "0 1px 3px rgba(0,0,0,0.07)",
+	} satisfies CSSProperties,
+
+	cardFlat: {
+		background: "#fff",
+		borderRadius: 8,
+		overflow: "hidden",
+		boxShadow: "0 1px 3px rgba(0,0,0,0.07)",
+	} satisfies CSSProperties,
+
+	groupHeader: {
+		padding: "7px 12px 6px",
+		fontSize: 10,
+		fontWeight: 700,
+		textTransform: "uppercase" as const,
+		letterSpacing: "0.08em",
+		color: "#4286c4",
+		background: "#f0f6fc",
+		borderBottom: "1px solid #d8eaf7",
+	} satisfies CSSProperties,
+
+	row: {
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "space-between",
+		gap: 8,
+		padding: "10px 12px",
+		cursor: "pointer",
+		userSelect: "none" as const,
+	} satisfies CSSProperties,
+
+	rowDivider: {
+		borderBottom: "1px solid #f0f0f0",
+	} satisfies CSSProperties,
+
+	label: {
+		flex: 1,
+		paddingRight: 12,
+		lineHeight: 1.45,
+		color: "#2a2a2a",
+	} satisfies CSSProperties,
+
+	loading: {
+		padding: "20px 16px",
+		color: "#999",
+		textAlign: "center" as const,
+	} satisfies CSSProperties,
+
+	toggle: {
+		position: "relative",
+		flexShrink: 0,
+		width: 40,
+		height: 22,
+		border: "none",
+		borderRadius: 11,
+		cursor: "pointer",
+		padding: 0,
+		transition: "background 0.2s",
+	} satisfies CSSProperties,
+
+	thumb: {
+		position: "absolute",
+		top: 2,
+		left: 0,
+		width: 18,
+		height: 18,
+		borderRadius: "50%",
+		background: "#fff",
+		boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
+		transition: "transform 0.2s",
+		display: "block",
+	} satisfies CSSProperties,
+
+	customizeButton: {
+		flexShrink: 0,
+		fontSize: 11,
+		padding: "4px 8px",
+		border: "1px solid #d0d0d0",
+		borderRadius: 4,
+		background: "#fff",
+		color: "#4286c4",
+		cursor: "pointer",
+	} satisfies CSSProperties,
+
+	backButton: {
+		flexShrink: 0,
+		border: "none",
+		background: "transparent",
+		color: "#fff",
+		fontSize: 13,
+		cursor: "pointer",
+		padding: 0,
+	} satisfies CSSProperties,
+
+	shortcutRow: {
+		display: "flex",
+		flexDirection: "column",
+		gap: 6,
+		padding: "10px 12px",
+	} satisfies CSSProperties,
+
+	shortcutLabel: {
+		color: "#2a2a2a",
+		lineHeight: 1.3,
+	} satisfies CSSProperties,
+
+	comboRow: {
+		display: "flex",
+		flexWrap: "wrap",
+		alignItems: "center",
+		gap: 6,
+	} satisfies CSSProperties,
+
+	chip: {
+		display: "inline-flex",
+		alignItems: "center",
+		gap: 4,
+		fontSize: 11,
+		fontFamily:
+			'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+		background: "#f0f6fc",
+		color: "#2a2a2a",
+		border: "1px solid #d8eaf7",
+		borderRadius: 4,
+		padding: "3px 6px",
+	} satisfies CSSProperties,
+
+	chipRemove: {
+		border: "none",
+		background: "transparent",
+		color: "#999",
+		cursor: "pointer",
+		fontSize: 12,
+		lineHeight: 1,
+		padding: 0,
+	} satisfies CSSProperties,
+
+	comboError: {
+		// flexBasis 100% forces this onto its own line within comboRow's
+		// flex-wrap layout, so long messages wrap within the popup's width
+		// instead of being clipped by a sibling chip's fixed width.
+		flexBasis: "100%",
+		fontSize: 11,
+		color: "#c0392b",
+		wordBreak: "break-word",
+	} satisfies CSSProperties,
+
+	resetRow: {
+		padding: "10px 12px",
+	} satisfies CSSProperties,
+
+	resetButton: {
+		width: "100%",
+		fontSize: 12,
+		padding: "8px 0",
+		border: "1px solid #d0d0d0",
+		borderRadius: 6,
+		background: "#fff",
+		color: "#c0392b",
+		cursor: "pointer",
+	} satisfies CSSProperties,
+
+	addButton: {
+		width: 22,
+		height: 22,
+		borderRadius: 4,
+		border: "1px solid #d0d0d0",
+		background: "#fff",
+		cursor: "pointer",
+		fontSize: 13,
+		lineHeight: 1,
+		color: "#4286c4",
+	} satisfies CSSProperties,
+
+	recorderInput: {
+		width: 170,
+		fontSize: 11,
+		padding: "3px 6px",
+		border: "1px solid #4286c4",
+		borderRadius: 4,
+		outline: "none",
+		background: "#fff",
+	} satisfies CSSProperties,
+};

--- a/src/shared/chart-shortcuts/actions.test.ts
+++ b/src/shared/chart-shortcuts/actions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+
+import { CHART_SHORTCUT_ACTIONS } from "./actions";
+
+describe("CHART_SHORTCUT_ACTIONS", () => {
+	test("has 31 actions", () => {
+		expect(CHART_SHORTCUT_ACTIONS).toHaveLength(31);
+	});
+
+	test("every action id is unique", () => {
+		const ids = CHART_SHORTCUT_ACTIONS.map((action) => action.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	test("every action has at least one default binding", () => {
+		for (const action of CHART_SHORTCUT_ACTIONS) {
+			expect(action.defaultBindings.length).toBeGreaterThan(0);
+		}
+	});
+
+	test("no two actions ship a colliding default binding", () => {
+		const seen = new Map<string, string>();
+		for (const action of CHART_SHORTCUT_ACTIONS) {
+			for (const combo of action.defaultBindings) {
+				const owner = seen.get(combo);
+				expect(
+					owner,
+					`"${combo}" claimed by both ${owner} and ${action.id}`,
+				).toBeUndefined();
+				seen.set(combo, action.id);
+			}
+		}
+	});
+});

--- a/src/shared/chart-shortcuts/actions.ts
+++ b/src/shared/chart-shortcuts/actions.ts
@@ -1,0 +1,288 @@
+export type ChartShortcutGroup =
+	| "applyInclude"
+	| "applyExclude"
+	| "subToggleInclude"
+	| "subToggleExclude"
+	| "allToggleInclude"
+	| "allToggleExclude"
+	| "advancedUser"
+	| "advancedExclude"
+	| "updateChart";
+
+export type ChartShortcutActionId =
+	| "includeGenre"
+	| "includeInfluence"
+	| "includeEither"
+	| "includeDescriptor"
+	| "excludeGenre"
+	| "excludeInfluence"
+	| "excludeEither"
+	| "excludeDescriptor"
+	| "toggleSubGenreInclude"
+	| "toggleSubInfluenceInclude"
+	| "toggleSubEitherInclude"
+	| "toggleSubDescriptorInclude"
+	| "toggleSubGenreExclude"
+	| "toggleSubInfluenceExclude"
+	| "toggleSubEitherExclude"
+	| "toggleSubDescriptorExclude"
+	| "toggleAllGenreInclude"
+	| "toggleAllInfluenceInclude"
+	| "toggleAllEitherInclude"
+	| "toggleAllDescriptorInclude"
+	| "toggleAllGenreExclude"
+	| "toggleAllInfluenceExclude"
+	| "toggleAllEitherExclude"
+	| "toggleAllDescriptorExclude"
+	| "onlyRatingsSelf"
+	| "onlyRatingsFollowing"
+	| "onlyRatingsFollowers"
+	| "excludeRated"
+	| "excludeCataloged"
+	| "excludeWishlisted"
+	| "updateChart";
+
+export type ChartShortcutAction = {
+	readonly id: ChartShortcutActionId;
+	readonly group: ChartShortcutGroup;
+	readonly label: string;
+	readonly hint: string;
+	// "primary" is resolved to the platform's default modifier (ctrl on
+	// macOS, alt elsewhere) by resolveDefaultBindings - see binding.ts.
+	readonly defaultBindings: readonly string[];
+};
+
+export const CHART_SHORTCUT_GROUP_LABELS: Record<ChartShortcutGroup, string> = {
+	applyInclude: "Include first result as",
+	applyExclude: "Exclude first result as",
+	subToggleInclude: "Include sub-genres/descriptors",
+	subToggleExclude: "Exclude sub-genres/descriptors",
+	allToggleInclude: "Must contain all",
+	allToggleExclude: "Only exclude items containing all",
+	advancedUser: "Only include ratings from",
+	advancedExclude: "Exclude releases",
+	updateChart: "Update chart",
+};
+
+export const CHART_SHORTCUT_ACTIONS: readonly ChartShortcutAction[] = [
+	{
+		id: "includeGenre",
+		group: "applyInclude",
+		label: "Include genre",
+		hint: 'include first genre result as "genre"',
+		defaultBindings: ["primary+Digit1"],
+	},
+	{
+		id: "includeInfluence",
+		group: "applyInclude",
+		label: "Include genre as influence",
+		hint: 'include first genre result as "influence"',
+		defaultBindings: ["primary+Digit2"],
+	},
+	{
+		id: "includeEither",
+		group: "applyInclude",
+		label: "Include genre as either",
+		hint: 'include first genre result as "either"',
+		defaultBindings: ["primary+Digit3"],
+	},
+	{
+		id: "includeDescriptor",
+		group: "applyInclude",
+		label: "Include descriptor",
+		hint: 'include first descriptor result as "descriptor"',
+		defaultBindings: ["primary+KeyD"],
+	},
+	{
+		id: "excludeGenre",
+		group: "applyExclude",
+		label: "Exclude genre",
+		hint: 'exclude first genre result as "genre"',
+		defaultBindings: ["primary+shift+Digit1"],
+	},
+	{
+		id: "excludeInfluence",
+		group: "applyExclude",
+		label: "Exclude genre as influence",
+		hint: 'exclude first genre result as "influence"',
+		defaultBindings: ["primary+shift+Digit2"],
+	},
+	{
+		id: "excludeEither",
+		group: "applyExclude",
+		label: "Exclude genre as either",
+		hint: 'exclude first genre result as "either"',
+		defaultBindings: ["primary+shift+Digit3"],
+	},
+	{
+		id: "excludeDescriptor",
+		group: "applyExclude",
+		label: "Exclude descriptor",
+		hint: 'exclude first descriptor result as "descriptor"',
+		defaultBindings: ["primary+shift+KeyD"],
+	},
+	{
+		id: "toggleSubGenreInclude",
+		group: "subToggleInclude",
+		label: "Include sub-genres: genres",
+		hint: 'toggle "Include sub-genres" for "genres"',
+		defaultBindings: ["primary+KeyZ"],
+	},
+	{
+		id: "toggleSubInfluenceInclude",
+		group: "subToggleInclude",
+		label: "Include sub-genres: influences",
+		hint: 'toggle "Include sub-genres" for "influences"',
+		defaultBindings: ["primary+KeyX"],
+	},
+	{
+		id: "toggleSubEitherInclude",
+		group: "subToggleInclude",
+		label: "Include sub-genres: either",
+		hint: 'toggle "Include sub-genres" for "either"',
+		defaultBindings: ["primary+KeyC"],
+	},
+	{
+		id: "toggleSubDescriptorInclude",
+		group: "subToggleInclude",
+		label: "Include sub-genres: descriptors",
+		hint: 'toggle "Include sub-genres" for "descriptors"',
+		defaultBindings: ["primary+KeyS"],
+	},
+	{
+		id: "toggleSubGenreExclude",
+		group: "subToggleExclude",
+		label: "Exclude sub-genres: genres",
+		hint: 'toggle "Exclude sub-genres" for "genres"',
+		defaultBindings: ["primary+shift+KeyZ"],
+	},
+	{
+		id: "toggleSubInfluenceExclude",
+		group: "subToggleExclude",
+		label: "Exclude sub-genres: influences",
+		hint: 'toggle "Exclude sub-genres" for "influences"',
+		defaultBindings: ["primary+shift+KeyX"],
+	},
+	{
+		id: "toggleSubEitherExclude",
+		group: "subToggleExclude",
+		label: "Exclude sub-genres: either",
+		hint: 'toggle "Exclude sub-genres" for "either"',
+		defaultBindings: ["primary+shift+KeyC"],
+	},
+	{
+		id: "toggleSubDescriptorExclude",
+		group: "subToggleExclude",
+		label: "Exclude sub-genres: descriptors",
+		hint: 'toggle "Exclude sub-genres" for "descriptors"',
+		defaultBindings: ["primary+shift+KeyS"],
+	},
+	{
+		id: "toggleAllGenreInclude",
+		group: "allToggleInclude",
+		label: "Must contain all: genres",
+		hint: 'toggle "Must contain all" for "genres"',
+		defaultBindings: ["primary+KeyQ"],
+	},
+	{
+		id: "toggleAllInfluenceInclude",
+		group: "allToggleInclude",
+		label: "Must contain all: influences",
+		hint: 'toggle "Must contain all" for "influences"',
+		defaultBindings: ["primary+KeyW"],
+	},
+	{
+		id: "toggleAllEitherInclude",
+		group: "allToggleInclude",
+		label: "Must contain all: either",
+		hint: 'toggle "Must contain all" for "either"',
+		defaultBindings: ["primary+KeyE"],
+	},
+	{
+		id: "toggleAllDescriptorInclude",
+		group: "allToggleInclude",
+		label: "Must contain all: descriptors",
+		hint: 'toggle "Must contain all" for "descriptors"',
+		defaultBindings: ["primary+KeyA"],
+	},
+	{
+		id: "toggleAllGenreExclude",
+		group: "allToggleExclude",
+		label: "Only exclude containing all: genres",
+		hint: 'toggle "Only exclude items containing all" for "genres"',
+		defaultBindings: ["primary+shift+KeyQ"],
+	},
+	{
+		id: "toggleAllInfluenceExclude",
+		group: "allToggleExclude",
+		label: "Only exclude containing all: influences",
+		hint: 'toggle "Only exclude items containing all" for "influences"',
+		defaultBindings: ["primary+shift+KeyW"],
+	},
+	{
+		id: "toggleAllEitherExclude",
+		group: "allToggleExclude",
+		label: "Only exclude containing all: either",
+		hint: 'toggle "Only exclude items containing all" for "either"',
+		defaultBindings: ["primary+shift+KeyE"],
+	},
+	{
+		id: "toggleAllDescriptorExclude",
+		group: "allToggleExclude",
+		label: "Only exclude containing all: descriptors",
+		hint: 'toggle "Only exclude items containing all" for "descriptors"',
+		defaultBindings: ["primary+shift+KeyA"],
+	},
+	{
+		id: "onlyRatingsSelf",
+		group: "advancedUser",
+		label: "Only ratings from myself",
+		hint: 'toggle "Only include ratings from myself"',
+		defaultBindings: ["primary+KeyR"],
+	},
+	{
+		id: "onlyRatingsFollowing",
+		group: "advancedUser",
+		label: "Only ratings from users I'm following",
+		hint: 'toggle "Only include ratings from users I\'m following"',
+		defaultBindings: ["primary+KeyF"],
+	},
+	{
+		id: "onlyRatingsFollowers",
+		group: "advancedUser",
+		label: "Only ratings from users who follow me",
+		hint: 'toggle "Only include ratings from users who follow me"',
+		defaultBindings: ["primary+KeyV"],
+	},
+	{
+		id: "excludeRated",
+		group: "advancedExclude",
+		label: "Exclude releases I've rated",
+		hint: 'toggle "Exclude releases I\'ve rated"',
+		defaultBindings: ["primary+shift+KeyR"],
+	},
+	{
+		id: "excludeCataloged",
+		group: "advancedExclude",
+		label: "Exclude releases I've cataloged",
+		hint: 'toggle "Exclude releases I\'ve cataloged"',
+		defaultBindings: ["primary+shift+KeyF"],
+	},
+	{
+		id: "excludeWishlisted",
+		group: "advancedExclude",
+		label: "Exclude releases I've wishlisted",
+		hint: 'toggle "Exclude releases I\'ve wishlisted"',
+		defaultBindings: ["primary+shift+KeyV"],
+	},
+	{
+		id: "updateChart",
+		group: "updateChart",
+		label: "Update chart",
+		hint: '"Update chart"',
+		// event.code distinguishes the main Enter key from the numpad one - the
+		// original event.key-based handler matched both, so both are kept here
+		// to avoid a silent regression for numpad-Enter users.
+		defaultBindings: ["primary+Enter", "primary+Space", "primary+NumpadEnter"],
+	},
+];

--- a/src/shared/chart-shortcuts/binding.test.ts
+++ b/src/shared/chart-shortcuts/binding.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "vitest";
+
+import type { ChartShortcutBindings } from "./binding";
+import {
+	comboFromEvent,
+	findComboConflict,
+	formatCombo,
+	hasRequiredModifier,
+	isModifierOnlyCode,
+	resolveDefaultBindings,
+} from "./binding";
+
+function keyCombo(overrides: Partial<Parameters<typeof comboFromEvent>[0]>) {
+	return {
+		code: "KeyA",
+		ctrlKey: false,
+		altKey: false,
+		shiftKey: false,
+		metaKey: false,
+		...overrides,
+	};
+}
+
+describe("comboFromEvent", () => {
+	test("orders modifiers as ctrl, alt, shift, meta", () => {
+		expect(
+			comboFromEvent(
+				keyCombo({
+					code: "KeyZ",
+					ctrlKey: true,
+					altKey: true,
+					shiftKey: true,
+					metaKey: true,
+				}),
+			),
+		).toBe("ctrl+alt+shift+meta+KeyZ");
+	});
+
+	test("includes only the held modifiers", () => {
+		expect(comboFromEvent(keyCombo({ code: "KeyD", ctrlKey: true }))).toBe(
+			"ctrl+KeyD",
+		);
+	});
+
+	test("uses the physical code, not the shifted character, for a digit", () => {
+		// On a US layout, shift+1 reports event.key === "!" - comboFromEvent must
+		// stay layout/shift independent by keying off event.code instead.
+		expect(
+			comboFromEvent(
+				keyCombo({ code: "Digit1", ctrlKey: true, shiftKey: true }),
+			),
+		).toBe("ctrl+shift+Digit1");
+	});
+
+	test("has no modifiers when none are held", () => {
+		expect(comboFromEvent(keyCombo({ code: "Enter" }))).toBe("Enter");
+	});
+
+	test("AltGr (altKey+ctrlKey together) never collides with a plain alt binding", () => {
+		// AltGr, common on European layouts for typing accented characters,
+		// reports as altKey+ctrlKey together - this must produce a distinct
+		// combo string from a plain "alt+..." binding so it can't misfire one.
+		const altGr = comboFromEvent(
+			keyCombo({ code: "KeyD", ctrlKey: true, altKey: true }),
+		);
+		expect(altGr).not.toBe(
+			comboFromEvent(keyCombo({ code: "KeyD", altKey: true })),
+		);
+	});
+});
+
+describe("formatCombo", () => {
+	test("formats a digit combo", () => {
+		expect(formatCombo("ctrl+shift+Digit1", false)).toBe("Ctrl + Shift + 1");
+	});
+
+	test("formats a letter combo", () => {
+		expect(formatCombo("ctrl+KeyZ", false)).toBe("Ctrl + Z");
+	});
+
+	test("formats named keys as-is", () => {
+		expect(formatCombo("ctrl+Enter", false)).toBe("Ctrl + Enter");
+		expect(formatCombo("ctrl+Space", false)).toBe("Ctrl + Space");
+	});
+
+	test("formats meta as Command", () => {
+		expect(formatCombo("meta+KeyA", false)).toBe("Command + A");
+	});
+
+	test("formats ctrl and alt as Ctrl/Alt off Mac", () => {
+		expect(formatCombo("ctrl+alt+KeyA", false)).toBe("Ctrl + Alt + A");
+	});
+
+	test("formats modifiers as glyphs, space-separated, on Mac", () => {
+		expect(formatCombo("ctrl+alt+shift+meta+KeyA", true)).toBe("⌃ ⌥ ⇧ ⌘ A");
+	});
+});
+
+describe("isModifierOnlyCode", () => {
+	test("recognizes modifier codes", () => {
+		expect(isModifierOnlyCode("ControlLeft")).toBe(true);
+		expect(isModifierOnlyCode("ShiftRight")).toBe(true);
+		expect(isModifierOnlyCode("MetaLeft")).toBe(true);
+		expect(isModifierOnlyCode("AltRight")).toBe(true);
+	});
+
+	test("does not flag a real key", () => {
+		expect(isModifierOnlyCode("KeyZ")).toBe(false);
+		expect(isModifierOnlyCode("Digit1")).toBe(false);
+	});
+});
+
+describe("hasRequiredModifier", () => {
+	test("rejects a bare key", () => {
+		expect(hasRequiredModifier("KeyZ")).toBe(false);
+	});
+
+	test("rejects shift-only", () => {
+		expect(hasRequiredModifier("shift+KeyD")).toBe(false);
+	});
+
+	test("accepts ctrl", () => {
+		expect(hasRequiredModifier("ctrl+KeyZ")).toBe(true);
+	});
+
+	test("accepts alt", () => {
+		expect(hasRequiredModifier("alt+KeyZ")).toBe(true);
+	});
+
+	test("accepts meta", () => {
+		expect(hasRequiredModifier("meta+KeyZ")).toBe(true);
+	});
+
+	test("accepts ctrl combined with shift", () => {
+		expect(hasRequiredModifier("ctrl+shift+Digit1")).toBe(true);
+	});
+});
+
+describe("findComboConflict", () => {
+	const bindings = {
+		includeGenre: ["ctrl+Digit1"],
+		includeInfluence: ["ctrl+Digit2"],
+		updateChart: ["ctrl+Enter", "ctrl+Space"],
+	} as unknown as ChartShortcutBindings;
+
+	test("finds the action already using a combo", () => {
+		expect(findComboConflict(bindings, "ctrl+Digit2", "includeGenre")).toBe(
+			"includeInfluence",
+		);
+	});
+
+	test("finds a conflict against either of an action's multiple combos", () => {
+		expect(findComboConflict(bindings, "ctrl+Space", "includeGenre")).toBe(
+			"updateChart",
+		);
+	});
+
+	test("returns null when the combo is unused", () => {
+		expect(findComboConflict(bindings, "ctrl+KeyZ", "includeGenre")).toBeNull();
+	});
+
+	test("ignores the excluded action's own combo", () => {
+		expect(
+			findComboConflict(bindings, "ctrl+Digit1", "includeGenre"),
+		).toBeNull();
+	});
+});
+
+describe("resolveDefaultBindings", () => {
+	test("resolves 'primary' to ctrl on Mac", () => {
+		expect(resolveDefaultBindings(["primary+Digit1"], true)).toEqual([
+			"ctrl+Digit1",
+		]);
+	});
+
+	test("resolves 'primary' to alt off Mac", () => {
+		expect(resolveDefaultBindings(["primary+Digit1"], false)).toEqual([
+			"alt+Digit1",
+		]);
+	});
+
+	test("resolves every combo in a multi-binding template", () => {
+		expect(
+			resolveDefaultBindings(
+				["primary+Enter", "primary+Space", "primary+NumpadEnter"],
+				false,
+			),
+		).toEqual(["alt+Enter", "alt+Space", "alt+NumpadEnter"]);
+	});
+});

--- a/src/shared/chart-shortcuts/binding.ts
+++ b/src/shared/chart-shortcuts/binding.ts
@@ -1,0 +1,123 @@
+import type { ChartShortcutActionId } from "./actions";
+
+export type ChartShortcutBindings = Record<ChartShortcutActionId, string[]>;
+
+// Structural rather than the real KeyboardEvent so this stays unit-testable
+// under Vitest's default node environment (no jsdom in this project).
+export type KeyCombo = {
+	code: string;
+	ctrlKey: boolean;
+	altKey: boolean;
+	shiftKey: boolean;
+	metaKey: boolean;
+};
+
+const MODIFIER_ONLY_CODES = new Set([
+	"ControlLeft",
+	"ControlRight",
+	"AltLeft",
+	"AltRight",
+	"ShiftLeft",
+	"ShiftRight",
+	"MetaLeft",
+	"MetaRight",
+]);
+
+const CODE_LABELS: Record<string, string> = {
+	Space: "Space",
+	Enter: "Enter",
+	NumpadEnter: "Numpad Enter",
+};
+
+// event.key is shift-dependent (shift+1 reports "!" on a US layout), which
+// would make ctrl+shift+1/2/3 unrecordable and unmatchable. event.code
+// reports the physical key regardless of modifiers, so combos are built on
+// it instead.
+export function comboFromEvent(event: KeyCombo): string {
+	const modifiers: string[] = [];
+	if (event.ctrlKey) modifiers.push("ctrl");
+	if (event.altKey) modifiers.push("alt");
+	if (event.shiftKey) modifiers.push("shift");
+	if (event.metaKey) modifiers.push("meta");
+	return [...modifiers, event.code].join("+");
+}
+
+function codeToLabel(code: string): string {
+	if (code in CODE_LABELS) return CODE_LABELS[code];
+	if (code.startsWith("Key")) return code.slice("Key".length);
+	if (code.startsWith("Digit")) return code.slice("Digit".length);
+	return code;
+}
+
+export const isMacPlatform =
+	typeof navigator !== "undefined" &&
+	/Mac|iPod|iPhone|iPad/.test(navigator.platform ?? "");
+
+function modifierLabels(mac: boolean): Record<string, string> {
+	if (mac) {
+		return { ctrl: "⌃", alt: "⌥", shift: "⇧", meta: "⌘" };
+	}
+	return { ctrl: "Ctrl", alt: "Alt", shift: "Shift", meta: "Command" };
+}
+
+// mac defaults to real platform detection; tests override it so results
+// don't depend on the host machine running the test.
+export function formatCombo(
+	combo: string,
+	mac: boolean = isMacPlatform,
+): string {
+	const parts = combo.split("+");
+	const code = parts[parts.length - 1];
+	const modifiers = parts.slice(0, -1);
+	const labels = modifierLabels(mac);
+	const separator = mac ? " " : " + ";
+	return [...modifiers.map((m) => labels[m] ?? m), codeToLabel(code)].join(
+		separator,
+	);
+}
+
+export function isModifierOnlyCode(code: string): boolean {
+	return MODIFIER_ONLY_CODES.has(code);
+}
+
+// Chart-shortcuts' listener deliberately fires while the chart search input
+// is focused (ctrl+1 while typing a query), so every combo must keep at
+// least one of ctrl/alt/meta - otherwise a bare letter or shift+letter
+// binding would swallow keystrokes meant for that input.
+export function hasRequiredModifier(combo: string): boolean {
+	const modifiers = combo.split("+").slice(0, -1);
+	return (
+		modifiers.includes("ctrl") ||
+		modifiers.includes("alt") ||
+		modifiers.includes("meta")
+	);
+}
+
+export function findComboConflict(
+	bindings: ChartShortcutBindings,
+	combo: string,
+	excludingActionId: ChartShortcutActionId,
+): ChartShortcutActionId | null {
+	for (const [actionId, combos] of Object.entries(bindings) as [
+		ChartShortcutActionId,
+		string[],
+	][]) {
+		if (actionId === excludingActionId) continue;
+		if (combos.includes(combo)) return actionId;
+	}
+	return null;
+}
+
+// Ctrl+letter (and Ctrl+1..8, which switches browser tabs) is heavily
+// claimed by browser/OS shortcuts on Windows/Linux, several of which a
+// content script can't even preventDefault - so ctrl isn't a safe default
+// modifier there, mirroring how Cmd is the claimed modifier on macOS.
+// A binding's "primary" placeholder resolves to ctrl on macOS and alt
+// elsewhere; users can still rebind any action to any combo they want.
+export function resolveDefaultBindings(
+	template: readonly string[],
+	mac: boolean = isMacPlatform,
+): string[] {
+	const modifier = mac ? "ctrl" : "alt";
+	return template.map((combo) => combo.replace("primary", modifier));
+}

--- a/src/shared/chart-shortcuts/settings.ts
+++ b/src/shared/chart-shortcuts/settings.ts
@@ -1,0 +1,73 @@
+import browser from "webextension-polyfill";
+
+import { isKeybindingsUpdatedMessage } from "~/shared/utils/messaging";
+import * as storage from "~/shared/utils/storage";
+
+import type { ChartShortcutActionId } from "./actions";
+import { CHART_SHORTCUT_ACTIONS } from "./actions";
+import type { ChartShortcutBindings } from "./binding";
+import { resolveDefaultBindings } from "./binding";
+
+const BINDINGS_STORAGE_KEY = "brym.chartShortcutBindings";
+
+type BindingOverrides = Partial<Record<ChartShortcutActionId, string[]>>;
+
+export function defaultBindings(): ChartShortcutBindings {
+	const result = {} as ChartShortcutBindings;
+	for (const action of CHART_SHORTCUT_ACTIONS) {
+		result[action.id] = resolveDefaultBindings(action.defaultBindings);
+	}
+	return result;
+}
+
+function mergeOverrides(overrides: BindingOverrides): ChartShortcutBindings {
+	const bindings = defaultBindings();
+	for (const action of CHART_SHORTCUT_ACTIONS) {
+		const override = overrides[action.id];
+		if (override) bindings[action.id] = override;
+	}
+	return bindings;
+}
+
+function overridesFrom(bindings: ChartShortcutBindings): BindingOverrides {
+	const defaults = defaultBindings();
+	const overrides: BindingOverrides = {};
+	for (const action of CHART_SHORTCUT_ACTIONS) {
+		const isDefault =
+			JSON.stringify(bindings[action.id]) ===
+			JSON.stringify(defaults[action.id]);
+		if (!isDefault) overrides[action.id] = bindings[action.id];
+	}
+	return overrides;
+}
+
+export async function getChartShortcutBindings(): Promise<ChartShortcutBindings> {
+	const overrides =
+		(await storage.get<BindingOverrides>(BINDINGS_STORAGE_KEY)) ?? {};
+	return mergeOverrides(overrides);
+}
+
+export async function setChartShortcutBindings(
+	next: ChartShortcutBindings,
+): Promise<void> {
+	const overrides = overridesFrom(next);
+	await storage.set(BINDINGS_STORAGE_KEY, overrides);
+
+	// Tells any already-open chart page to pick up the change immediately -
+	// see the background script's "keybindingsChanged" listener. storage.local
+	// above is already the source of truth, so this is a best-effort nudge.
+	void browser.runtime.sendMessage({
+		type: "keybindingsChanged",
+		data: { value: JSON.stringify(overrides) },
+	});
+}
+
+export function subscribeToChartShortcutBindings(
+	onChange: (bindings: ChartShortcutBindings) => void,
+): void {
+	browser.runtime.onMessage.addListener((message) => {
+		if (!isKeybindingsUpdatedMessage(message)) return;
+		const overrides = JSON.parse(message.data.value) as BindingOverrides;
+		onChange(mergeOverrides(overrides));
+	});
+}

--- a/src/shared/pages.ts
+++ b/src/shared/pages.ts
@@ -18,6 +18,7 @@ export const pages = {
 	map: "/artist/",
 	hideVotes: "/r",
 	hideRatings: "/",
+	chartShortcuts: "/charts/",
 } as const;
 
 export type PageKey = keyof typeof pages;
@@ -42,6 +43,7 @@ export const pageLabels: Record<PageKey, string> = {
 	map: "Artist Location Map",
 	hideVotes: "Hide Votes on Genre/Descriptor Pages",
 	hideRatings: "Hide Ratings If Unrated",
+	chartShortcuts: "Chart Shortcuts",
 };
 
 export const pageGroupLabels: Partial<Record<string, string>> = {
@@ -56,7 +58,7 @@ export const pageGroupLabels: Partial<Record<string, string>> = {
 	"/rdescriptor/vote_history": "Descriptor Vote History",
 	"/misc/media_link_you_know": "Media Link You Know",
 	"/": "Global",
-	"/charts/": "Film Charts",
+	"/charts/": "Charts",
 	"/film_genre/": "Film Genre",
 	"/artist/": "Artist Pages",
 };
@@ -94,6 +96,8 @@ export const pageHints: Record<PageKey, string> = {
 		"On genre and descriptor pages, adds toggle buttons to hide user votes.",
 	hideRatings:
 		"Hides ratings on supported pages; release and artist ratings remain visible when you have rated them.",
+	chartShortcuts:
+		"Adds keyboard shortcuts for applying genre/descriptor matches, toggling sub-genre and 'must contain all' options, and updating the chart to chart pages.",
 };
 
 // Page keys whose features are global and should not affect the toolbar icon

--- a/src/shared/utils/array.ts
+++ b/src/shared/utils/array.ts
@@ -42,3 +42,17 @@ export const equals = <T>(a: T[], b: T[]): boolean =>
 	Array.isArray(b) &&
 	a.length === b.length &&
 	a.every((value, index) => JSON.stringify(value) === JSON.stringify(b[index]));
+
+export const groupBy = <T, K>(
+	items: readonly T[],
+	keyFor: (item: T) => K,
+): [K, T[]][] => {
+	const map = new Map<K, T[]>();
+	for (const item of items) {
+		const key = keyFor(item);
+		const group = map.get(key) ?? [];
+		group.push(item);
+		map.set(key, group);
+	}
+	return [...map.entries()];
+};

--- a/src/shared/utils/messaging.ts
+++ b/src/shared/utils/messaging.ts
@@ -51,6 +51,39 @@ export type ScriptResponse = {
 	type: "script";
 };
 
+// One-way messages (not a request/response pair, no `id`) for broadcasting a
+// chart-shortcut rebind to any already-open chart page, so it takes effect
+// without a refresh. Popup -> background -> matching tabs.
+export type KeybindingsChangedMessage = {
+	type: "keybindingsChanged";
+	data: {
+		value: string;
+	};
+};
+
+export type KeybindingsUpdatedMessage = {
+	type: "keybindingsUpdated";
+	data: {
+		value: string;
+	};
+};
+
+export const isKeybindingsChangedMessage = (
+	o: unknown,
+): o is KeybindingsChangedMessage =>
+	typeof o === "object" &&
+	o !== null &&
+	"type" in o &&
+	o.type === "keybindingsChanged";
+
+export const isKeybindingsUpdatedMessage = (
+	o: unknown,
+): o is KeybindingsUpdatedMessage =>
+	typeof o === "object" &&
+	o !== null &&
+	"type" in o &&
+	o.type === "keybindingsUpdated";
+
 export type BackgroundRequest = FetchRequest | DownloadRequest | ScriptRequest;
 export type BackgroundResponse =
 	| FetchResponse


### PR DESCRIPTION
## Summary

Ports an existing keyboard-shortcut userscript I've used for months into a toggleable feature module for the chart-builder page (`/charts/...`):

- Keyboard shortcuts for including/excluding the first genre/secondary-genre/either-genre/descriptor search result
- Shortcuts for toggling "Include sub-genres" and "Must contain all" per category
- Shortcuts for the advanced options (self/following/followers ratings, exclude rated/cataloged/wishlisted)
- A shortcut for "Update chart"
- Reads RYM's own live browse-widget state via page-world script injection, rather than approximating it with a separate fetch, so shortcuts always match what the native dropdown would show
- A Show/Hide toggle for the on-page shortcut hint list

## Modifier key

The shortcut modifier is platform-conditional: **Control on macOS**, **Alt everywhere else**. Ctrl+letter is heavily claimed by browser/OS shortcuts on Windows/Linux (several of which a content script can't even `preventDefault`), so Control isn't a safe default off macOS — mirroring how Cmd is the claimed modifier on macOS and Control is comparatively free there. The Alt path also excludes AltGr (`altKey && ctrlKey` together, common on European keyboard layouts) so typing accented characters in the search box doesn't misfire a shortcut.

**Note:** I've only been able to test the macOS/Control path myself. The Alt/Windows path is implemented and passes type-checking/lint, but I don't have a Windows machine to verify against — would appreciate a check from anyone who can test it, particularly the AltGr guard.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx biome check` / `npx eslint` pass on the new/changed files
- [x] `npm run build` succeeds
- [x] Manually tested on macOS Safari/Chrome (Control modifier)
- [ ] Alt modifier on Windows — untested, feedback welcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)