### PR TITLE
fix: Qobuz finder returns no results and 404s on titles with slashes

### DIFF
--- a/src/shared/services/qobuz/search.ts
+++ b/src/shared/services/qobuz/search.ts
@@ -9,15 +9,14 @@ export const search: SearchFunction = async ({ artist, title }) => {
 	});
 
 	const html = new DOMParser().parseFromString(response, "text/html");
-	const topResult = html.querySelector(".ReleaseCard");
-	if (!topResult) {
-		return undefined;
-	}
+	const firstLink = html.querySelector(
+		'#release-card-list a[href*="/us-en/album/"]',
+	) as HTMLAnchorElement | null;
+	if (!firstLink) return undefined;
 
-	const url = topResult.querySelector("a")?.href;
-
-	const album_id = url?.substring(url?.lastIndexOf("/"));
+	const href = firstLink.getAttribute("href") ?? "";
+	const album_id = href.substring(href.lastIndexOf("/"));
 	const streaming_url = `https://open.qobuz.com/album${album_id}`;
 
-	return streaming_url ?? undefined;
+	return streaming_url;
 };

--- a/src/shared/services/qobuz/search.ts
+++ b/src/shared/services/qobuz/search.ts
@@ -3,8 +3,9 @@ import { fetch } from "~/shared/utils/fetch";
 import type { SearchFunction } from "../types";
 
 export const search: SearchFunction = async ({ artist, title }) => {
+	const query = encodeURIComponent(`${artist} ${title}`.replace(/\//g, " "));
 	const response = await fetch({
-		url: `https://www.qobuz.com/us-en/search/albums/${artist} ${title}`,
+		url: `https://www.qobuz.com/us-en/search/albums/${query}`,
 		method: "GET",
 	});
 


### PR DESCRIPTION
## Summary
- Qobuz's search page markup changed, so `search()`'s `.ReleaseCard` selector no longer matches anything — the Qobuz finder currently returns "not found" for every search, working or not. Updated to the current `#release-card-list a[href*="/us-en/album/"]` structure.
- Separately, the search query is embedded directly in the URL path (`/us-en/search/albums/{artist} {title}`) rather than passed as a query parameter. Any artist/title containing `/` (e.g. a release with a `/`-separated title) splits into an extra path segment and 404s. `encodeURIComponent` alone doesn't survive the round trip — Qobuz's edge normalizes `%2F` back to a literal slash before routing — so the slash is replaced with a space before encoding the rest of the query.

Both verified against the live Qobuz search endpoint via this repo's `import-check` debug page (`src/modules/import-check/`) before and after.

## Test plan
- [ ] Confirm `search()` resolves a normal artist/title against Qobuz (e.g. via the import-check search panel)
- [ ] Confirm a title containing `/` (e.g. "The Edge of the Cliff / Dark Rain") no longer 404s