### PR TITLE
feat: auto-format artist links inserted into track titles

### DIFF
--- a/src/modules/release-submission/app.tsx
+++ b/src/modules/release-submission/app.tsx
@@ -1,3 +1,4 @@
+import injectArtistLinkFormatting from "./use-cases/artist-link-formatting";
 import injectCatalogNumberControls from "./use-cases/catalog-number-controls";
 import injectCreditsControls from "./use-cases/credits-controls";
 import injectDateControls from "./use-cases/date-controls";
@@ -10,6 +11,7 @@ export const main = () =>
 	Promise.all([
 		injectImportControls(),
 		injectTracklistControls(),
+		injectArtistLinkFormatting(),
 		injectFileUnderControls(),
 		injectCreditsControls(),
 		injectLabelControls(),

--- a/src/modules/release-submission/dom.d.ts
+++ b/src/modules/release-submission/dom.d.ts
@@ -3,10 +3,19 @@ import type { ResolveData } from "~/shared/services/types";
 type CustomEventMap = {
 	importEvent: CustomEvent<ResolveData>;
 	fillEvent: CustomEvent<FillData>;
+	EbrArtistShortcutInsertedEvent: CustomEvent<ArtistShortcutInsertedDetail>;
 };
 
 export type FillData = {
 	filledField: "date";
+};
+
+export type ArtistShortcutInsertedDetail = {
+	type: string;
+	assocId: string;
+	text?: string;
+	targetId: string;
+	previousValue?: string;
 };
 
 declare global {

--- a/src/modules/release-submission/use-cases/artist-link-formatting.tsx
+++ b/src/modules/release-submission/use-cases/artist-link-formatting.tsx
@@ -1,0 +1,25 @@
+import {
+	buildArtistToken,
+	insertArtistShortcut,
+	isTrackTitleFieldId,
+} from "../utils/artist-shortcuts";
+import { patchCreateShortcut } from "../utils/page-functions";
+
+export default async function injectArtistLinkFormatting() {
+	document.addEventListener("EbrArtistShortcutInsertedEvent", (event) => {
+		const { type, assocId, text, targetId, previousValue } = event.detail;
+		if (type !== "a") return;
+		if (previousValue === undefined) return;
+		if (!isTrackTitleFieldId(targetId)) return;
+
+		const target = document.getElementById(targetId);
+		if (!(target instanceof HTMLInputElement)) return;
+
+		target.value = insertArtistShortcut(
+			previousValue,
+			buildArtistToken(assocId, text),
+		);
+	});
+
+	patchCreateShortcut();
+}

--- a/src/modules/release-submission/utils/artist-shortcuts.test.ts
+++ b/src/modules/release-submission/utils/artist-shortcuts.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	buildArtistToken,
+	insertArtistShortcut,
+	isTrackTitleFieldId,
+} from "./artist-shortcuts";
+
+describe("insertArtistShortcut", () => {
+	const tests = [
+		["Track", "[ArtistX] - Track"],
+		["Artist1 - Track", "[ArtistX] - Artist1 - Track"],
+		["[Artist1] - Track", "[Artist1] & [ArtistX] - Track"],
+		["Artist1 & Artist2 - Track", "[ArtistX] - Artist1 & Artist2 - Track"],
+		["Artist1 & [Artist2] - Track", "Artist1, [Artist2] & [ArtistX] - Track"],
+		["[Artist1] & Artist2 - Track", "[Artist1], Artist2 & [ArtistX] - Track"],
+		[
+			"[Artist1] & [Artist2] - Track",
+			"[Artist1], [Artist2] & [ArtistX] - Track",
+		],
+	] as const;
+
+	test.each(tests)("%s -> %s", (input, output) =>
+		expect(insertArtistShortcut(input, "[ArtistX]")).toBe(output));
+
+	test("does not misparse a track name containing its own separator", () => {
+		// no [ArtistXXXX] link before the first " - ", so the whole field
+		// is kept intact as the track name rather than being split apart
+		expect(
+			insertArtistShortcut("A-Ha - Take On Me - 12in Mix", "[ArtistX]"),
+		).toBe("[ArtistX] - A-Ha - Take On Me - 12in Mix");
+	});
+});
+
+describe("buildArtistToken", () => {
+	test("without custom text", () => {
+		expect(buildArtistToken("1566274")).toBe("[Artist1566274]");
+	});
+
+	test("with custom text", () => {
+		expect(buildArtistToken("1566274", "custom")).toBe(
+			"[Artist1566274,custom]",
+		);
+	});
+});
+
+describe("isTrackTitleFieldId", () => {
+	test.each([
+		["track_track_title1", true],
+		["track_track_title12", true],
+		["track_title", false],
+		["va_labels", false],
+		["track_advanced", false],
+	])("%s -> %s", (id, expected) => {
+		expect(isTrackTitleFieldId(id)).toBe(expected);
+	});
+});

--- a/src/modules/release-submission/utils/artist-shortcuts.ts
+++ b/src/modules/release-submission/utils/artist-shortcuts.ts
@@ -1,0 +1,41 @@
+import { arrayToArtists } from "~/shared/utils/string";
+
+const TRACK_TITLE_ID_PATTERN = /^track_track_title\d+$/;
+const ARTIST_SEPARATOR = " - ";
+const ARTIST_LIST_DELIMITER = /\s*&\s*|\s*,\s*/;
+const ARTIST_LINK_PATTERN = /\[Artist\d+]/;
+
+export const isTrackTitleFieldId = (id: string): boolean =>
+	TRACK_TITLE_ID_PATTERN.test(id);
+
+export const buildArtistToken = (assocId: string, text?: string): string =>
+	text ? `[Artist${assocId},${text}]` : `[Artist${assocId}]`;
+
+// Appends artistToken to the field's existing linked artist list (if any),
+// leaving the track name and any unlinked artist text untouched.
+export const insertArtistShortcut = (
+	currentValue: string,
+	artistToken: string,
+): string => {
+	const separatorIndex = currentValue.indexOf(ARTIST_SEPARATOR);
+	const artistListPart =
+		separatorIndex === -1
+			? currentValue
+			: currentValue.slice(0, separatorIndex);
+
+	// No existing [ArtistXXXX] link before the separator: nothing to parse or
+	// join, so the whole field is treated as the track name.
+	if (!ARTIST_LINK_PATTERN.test(artistListPart)) {
+		return `${artistToken}${ARTIST_SEPARATOR}${currentValue}`;
+	}
+
+	const trackNamePart = currentValue.slice(
+		separatorIndex + ARTIST_SEPARATOR.length,
+	);
+	const artists = artistListPart
+		.split(ARTIST_LIST_DELIMITER)
+		.filter((artist) => artist.length > 0);
+	artists.push(artistToken);
+
+	return `${arrayToArtists(artists)}${ARTIST_SEPARATOR}${trackNamePart}`;
+};

--- a/src/modules/release-submission/utils/page-functions.ts
+++ b/src/modules/release-submission/utils/page-functions.ts
@@ -1,5 +1,8 @@
 import { runScript } from "~/shared/utils/dom";
 
+const CREATE_SHORTCUT_PATCH_ATTEMPTS = 20;
+const CREATE_SHORTCUT_PATCH_INTERVAL_MS = 200;
+
 export const selectShortcut = (
 	type: string,
 	id: number,
@@ -13,3 +16,42 @@ export const selectShortcut = (
 // window.parent.goInfobox(897)
 export const goInfobox = (id: number): void =>
 	void runScript(`goInfobox(${id})`);
+
+// window.currentElement isn't visible to the content script's isolated
+// world, so window.createShortcut has to be wrapped from injected page-world
+// code; it polls because this content script runs at document_start, before
+// the page's own inline script (which defines createShortcut) has executed.
+export const patchCreateShortcut = (): void =>
+	void runScript(`
+		(function () {
+			var attempts = 0;
+			var interval = setInterval(function () {
+				attempts += 1;
+				if (attempts > ${CREATE_SHORTCUT_PATCH_ATTEMPTS}) {
+					clearInterval(interval);
+					return;
+				}
+				if (typeof window.createShortcut !== "function") return;
+				clearInterval(interval);
+
+				var original = window.createShortcut;
+				window.createShortcut = function (type, assocId, text) {
+					var target = window.currentElement;
+					var previousValue = target ? target.value : undefined;
+					var result = original.apply(window, arguments);
+					if (target) {
+						document.dispatchEvent(new CustomEvent("EbrArtistShortcutInsertedEvent", {
+							detail: {
+								type: type,
+								assocId: String(assocId),
+								text: text,
+								targetId: target.id,
+								previousValue: previousValue
+							}
+						}));
+					}
+					return result;
+				};
+			}, ${CREATE_SHORTCUT_PATCH_INTERVAL_MS});
+		})();
+	`);


### PR DESCRIPTION
## Summary
- Clicking an artist in the "Insert link to artist or work" popup now appends the linked `[ArtistX]` shortcut to the track title field's existing artist list (joined per RYM's comma/ampersand standard) instead of inserting raw text at the cursor.
- Also ignores saved debug screenshots/HTML dumps used while reverse-engineering RYM's shortcut-insertion mechanism.

## Test plan
- [x] `npm run build` succeeds
- [x] `npx vitest run src/modules/release-submission/utils/artist-shortcuts.test.ts` passes (15 tests)